### PR TITLE
add 2 scrollbars to the TreeViewsContainer Grid

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -251,6 +251,9 @@ const App = () => {
                                     style={{
                                         borderRight:
                                             '1px solid rgba(81, 81, 81, 1)',
+                                        height: '100%',
+                                        overflow: 'auto',
+                                        display: 'flex',
                                     }}
                                 >
                                     <TreeViewsContainer />

--- a/src/components/directory-tree-view.js
+++ b/src/components/directory-tree-view.js
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
         padding: theme.spacing(0.5),
     },
     treeItemRoot: {
+        userSelect: 'none',
         '&:focus > $treeItemContent $treeItemLabel, .focused': {
             borderRadius: theme.spacing(2),
             backgroundColor: theme.row.primary,
@@ -65,7 +66,8 @@ const useStyles = makeStyles((theme) => ({
     },
     treeItemLabelText: {
         fontWeight: 'inherit',
-        flexGrow: 1,
+        flexGrow: 0,
+        marginRight: '5px',
     },
     icon: {
         marginRight: theme.spacing(1),
@@ -169,22 +171,6 @@ const DirectoryTreeView = ({
                             handleContextMenuClick(e, node.elementUuid)
                         }
                     >
-                        <Tooltip
-                            TransitionComponent={Zoom}
-                            disableFocusListener
-                            disableTouchListener
-                            enterDelay={1000}
-                            enterNextDelay={1000}
-                            title={node.elementName}
-                            placement="bottom-end"
-                        >
-                            <Typography
-                                noWrap
-                                className={classes.treeItemLabelText}
-                            >
-                                {node.elementName}
-                            </Typography>
-                        </Tooltip>
                         {node.accessRights?.isPrivate ? (
                             <Tooltip
                                 TransitionComponent={Zoom}
@@ -193,12 +179,29 @@ const DirectoryTreeView = ({
                                 enterDelay={1000}
                                 enterNextDelay={1000}
                                 title={<FormattedMessage id="private" />}
-                                placement="right"
+                                placement="bottom"
                                 arrow
                             >
                                 <LockIcon className={classes.icon} />
                             </Tooltip>
                         ) : null}
+                        <Tooltip
+                            TransitionComponent={Zoom}
+                            disableFocusListener
+                            disableTouchListener
+                            enterDelay={1000}
+                            enterNextDelay={1000}
+                            title={node.elementName}
+                            arrow
+                            placement="bottom-start"
+                        >
+                            <Typography
+                                noWrap
+                                className={classes.treeItemLabelText}
+                            >
+                                {node.elementName}
+                            </Typography>
+                        </Tooltip>
                     </div>
                 }
                 ContentProps={{


### PR DESCRIPTION
To explore and navigate into a huge or deep tree, scrollbars have been added.
Impacts:
- there is no more truncated names (ending with "...")
- the private/lock icon is now at the left of the directory name

Also changed: user selection in the tree view is now disabled.