### PR TITLE
disable drag&drop on BreadCrumbs Links

### DIFF
--- a/src/components/directory-breadcrumbs.js
+++ b/src/components/directory-breadcrumbs.js
@@ -87,6 +87,9 @@ const DirectoryBreadcrumbs = () => {
                         key={dir.elementUuid}
                         href="/"
                         onClick={(event) => handleSelect(event, dir)}
+                        onDragStart={(event) => {
+                            event.preventDefault();
+                        }}
                         underline="hover"
                     >
                         {index === 0 ? (


### PR DESCRIPTION
Drag and drop is pointless in the BreadCrumbs area, so disable it