### PR TITLE
Fix to allow right-clic everywhere in the tree view grid

### DIFF
--- a/src/components/directory-tree-view.js
+++ b/src/components/directory-tree-view.js
@@ -66,8 +66,7 @@ const useStyles = makeStyles((theme) => ({
     },
     treeItemLabelText: {
         fontWeight: 'inherit',
-        flexGrow: 0,
-        marginRight: '5px',
+        flexGrow: 1,
     },
     icon: {
         marginRight: theme.spacing(1),

--- a/src/components/tree-views-container.js
+++ b/src/components/tree-views-container.js
@@ -569,6 +569,7 @@ const TreeViewsContainer = () => {
                     display: 'flex',
                     flexDirection: 'column',
                     height: '100%',
+                    flexGrow: 1,
                 }}
                 onContextMenu={(e) => onContextMenu(e, null)}
             >


### PR DESCRIPTION
An issue has been found on US 1035: right-clic is not available on the whole tree view panel