### PR TITLE
HTTP404 -> HTTP204

### DIFF
--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -422,11 +422,10 @@ export function elementExists(directoryUuid, elementName, type) {
     console.debug(existsElementUrl);
     return backendFetch(existsElementUrl, { method: 'head' }).then(
         (response) => {
-            return response.ok
-                ? true
-                : response.status === 404
-                ? false
-                : Promise.reject(response.statusText);
+            if (response.ok) {
+                return response.status !== 204; // HTTP 204 : No-content
+            }
+            return Promise.reject(response.statusText);
         }
     );
 }
@@ -459,11 +458,10 @@ export function rootDirectoryExists(directoryName) {
 
     return backendFetch(existsRootDirectoryUrl, { method: 'head' }).then(
         (response) => {
-            return response.ok
-                ? true
-                : response.status === 404
-                ? false
-                : Promise.reject(response.statusText);
+            if (response.ok) {
+                return response.status !== 204; // HTTP 204 : No-content
+            }
+            return Promise.reject(response.statusText);
         }
     );
 }


### PR DESCRIPTION
Uses a HTTP204 return code instead of HTTP404 when checking if a directory or element exists.