### PR TITLE
fix element draging when trying to select text

### DIFF
--- a/src/components/dialogs/manual-filter-creation-dialog.js
+++ b/src/components/dialogs/manual-filter-creation-dialog.js
@@ -63,11 +63,9 @@ const ManualFilterRow = ({
         <Draggable draggableId={id} index={index} key={id + value + index}>
             {(provided) => (
                 <div
-                    draggable="true"
-                    ref={provided.innerRef}
                     style={{ width: '100%' }}
+                    ref={provided.innerRef}
                     {...provided.draggableProps}
-                    {...provided.dragHandleProps}
                 >
                     <Grid
                         container
@@ -75,9 +73,8 @@ const ManualFilterRow = ({
                         spacing={2}
                         key={index + id + 'container item'}
                         sx={{ width: '100%', height: '50%' }}
-                        ref={provided.innerRef}
                     >
-                        <Grid xs={1} item draggable="true">
+                        <Grid xs={1} item>
                             <IconButton
                                 {...provided.dragHandleProps}
                                 key={id + index + 'drag'}
@@ -105,7 +102,6 @@ const ManualFilterRow = ({
                                 }
                                 error={value?.equipmentID === ''}
                                 required
-                                draggable="false"
                             />
                         </Grid>
                         {isGeneratorOrLoad && (

--- a/src/components/dialogs/manual-filter-creation-dialog.js
+++ b/src/components/dialogs/manual-filter-creation-dialog.js
@@ -66,6 +66,8 @@ const ManualFilterRow = ({
                     draggable="true"
                     ref={provided.innerRef}
                     style={{ width: '100%' }}
+                    {...provided.draggableProps}
+                    {...provided.dragHandleProps}
                 >
                     <Grid
                         container
@@ -73,12 +75,9 @@ const ManualFilterRow = ({
                         spacing={2}
                         key={index + id + 'container item'}
                         sx={{ width: '100%', height: '50%' }}
-                        draggable="true"
                         ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
                     >
-                        <Grid xs={1} item>
+                        <Grid xs={1} item draggable="true">
                             <IconButton
                                 {...provided.dragHandleProps}
                                 key={id + index + 'drag'}
@@ -106,6 +105,7 @@ const ManualFilterRow = ({
                                 }
                                 error={value?.equipmentID === ''}
                                 required
+                                draggable="false"
                             />
                         </Grid>
                         {isGeneratorOrLoad && (


### PR DESCRIPTION
fixed the issue that occurs when trying to select a text (equipment id) in the manual filter table with the mouse, the line is dragged and you cannot select it.