### PR TITLE
Refactor filter dialogs: Change file names and component names for homogeneity

### DIFF
--- a/src/components/dialogs/create-filter-dialog.js
+++ b/src/components/dialogs/create-filter-dialog.js
@@ -29,7 +29,7 @@ import { useSelector } from 'react-redux';
 import { ElementType, FilterType } from '../../utils/elementType';
 import CircularProgress from '@mui/material/CircularProgress';
 import CheckIcon from '@mui/icons-material/Check';
-import CriteriaFilterDialogContent from './criteria-filter-dialog-content';
+import CriteriaBasedFilterDialogContent from './criteria-based-filter-dialog-content';
 import ExplicitNamingFilterDialogContent from './explicit-naming-filter-dialog-content';
 import { DialogContentText } from '@mui/material';
 
@@ -375,7 +375,7 @@ const CreateFilterDialog = ({
                 <Dialog
                     open={isConfirmationPopupOpen}
                     aria-labelledby="dialog-title-change-filter-type"
-                    onKeyPress={() => handlePopupConfirmation(false)}
+                    onKeyPress={() => handlePopupConfirmation()}
                 >
                     <DialogTitle id={'dialog-title-change-filter-type'}>
                         {'Confirmation'}
@@ -447,7 +447,7 @@ const CreateFilterDialog = ({
                         />
                     </RadioGroup>
                     {newListType === FilterType.CRITERIA ? (
-                        <CriteriaFilterDialogContent
+                        <CriteriaBasedFilterDialogContent
                             open={open && filterType === FilterType.CRITERIA}
                             isFilterCreation={true}
                             handleFilterCreation={handleCallback}

--- a/src/components/dialogs/criteria-based-filter-dialog-content.js
+++ b/src/components/dialogs/criteria-based-filter-dialog-content.js
@@ -81,7 +81,7 @@ export const FilterTypeSelection = ({
     );
 };
 
-export const CriteriaFilterDialogContent = ({
+export const CriteriaBasedFilterDialogContent = ({
     id,
     open,
     contentType,
@@ -255,4 +255,4 @@ export const CriteriaFilterDialogContent = ({
     );
 };
 
-export default CriteriaFilterDialogContent;
+export default CriteriaBasedFilterDialogContent;

--- a/src/components/dialogs/criteria-based-filter-dialog.js
+++ b/src/components/dialogs/criteria-based-filter-dialog.js
@@ -15,7 +15,7 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import { saveFilter, saveFormContingencyList } from '../../utils/rest-api';
 import { ElementType } from '../../utils/elementType';
-import CriteriaFilterDialogContent from './criteria-filter-dialog-content';
+import CriteriaBasedFilterDialogContent from './criteria-based-filter-dialog-content';
 
 const useStyles = makeStyles(() => ({
     dialogPaper: {
@@ -105,7 +105,7 @@ export const CriteriaBasedFilterDialog = ({
         >
             <DialogTitle>{title}</DialogTitle>
             <DialogContent>
-                <CriteriaFilterDialogContent
+                <CriteriaBasedFilterDialogContent
                     id={id}
                     open={open}
                     contentType={contentType}

--- a/src/components/dialogs/explicit-naming-filter-creation-dialog.js
+++ b/src/components/dialogs/explicit-naming-filter-creation-dialog.js
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const ExplicitNamingCreationDialog = ({
+const ExplicitNamingFilterCreationDialog = ({
     id,
     open,
     onClose,
@@ -181,7 +181,7 @@ const ExplicitNamingCreationDialog = ({
     );
 };
 
-ExplicitNamingCreationDialog.prototype = {
+ExplicitNamingFilterCreationDialog.prototype = {
     id: PropTypes.string,
     name: PropTypes.string,
     onClose: PropTypes.func.isRequired,
@@ -190,4 +190,4 @@ ExplicitNamingCreationDialog.prototype = {
     isFilterCreation: PropTypes.bool,
 };
 
-export default ExplicitNamingCreationDialog;
+export default ExplicitNamingFilterCreationDialog;

--- a/src/components/dialogs/explicit-naming-filter-dialog-content.js
+++ b/src/components/dialogs/explicit-naming-filter-dialog-content.js
@@ -20,7 +20,7 @@ import { Draggable } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 import { Alert, Checkbox, Input, Tooltip } from '@mui/material';
 import { filterEquipmentDefinition } from '../../utils/equipment-types';
-import { FilterTypeSelection } from './criteria-filter-dialog-content';
+import { FilterTypeSelection } from './criteria-based-filter-dialog-content';
 
 const useStyles = makeStyles(() => ({
     dialogPaper: {

--- a/src/components/directory-content.js
+++ b/src/components/directory-content.js
@@ -25,14 +25,18 @@ import {
     ElementType,
     FilterType,
 } from '../utils/elementType';
-import { DEFAULT_CELL_PADDING, OverflowableText } from '@gridsuite/commons-ui';
+import {
+    DEFAULT_CELL_PADDING,
+    OverflowableText,
+    useSnackMessage,
+} from '@gridsuite/commons-ui';
 import { Checkbox } from '@mui/material';
 
 import { fetchElementsInfos } from '../utils/rest-api';
 
 import ScriptDialog from './dialogs/script-dialog';
-import CriteriaBasedFilterDialog from './dialogs/criteria-filter-dialog';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import CriteriaBasedFilterDialog from './dialogs/criteria-based-filter-dialog';
+import ExplicitNamingFilterCreationDialog from './dialogs/explicit-naming-filter-creation-dialog';
 
 import ContentContextualMenu from './menus/content-contextual-menu';
 import ContentToolbar from './toolbars/content-toolbar';
@@ -41,7 +45,6 @@ import PhotoIcon from '@mui/icons-material/Photo';
 import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 import ArticleIcon from '@mui/icons-material/Article';
 import OfflineBoltIcon from '@mui/icons-material/OfflineBolt';
-import ExplicitNamingCreationDialog from './dialogs/explicit-naming-filter-creation-dialog';
 
 const circularProgressSize = '70px';
 
@@ -184,7 +187,7 @@ const DirectoryContent = () => {
         useState(null);
     const [openCriteriaBasedFilterDialog, setOpenCriteriaBasedFilterDialog] =
         React.useState(false);
-    const handleCloseGenericFilterDialog = () => {
+    const handleCloseCriteriaBasedFilterDialog = () => {
         setOpenCriteriaBasedFilterDialog(false);
         setCurrentCriteriaBasedFilterId(null);
         setActiveElement(null);
@@ -795,7 +798,7 @@ const DirectoryContent = () => {
                 title={useIntl().formatMessage({ id: 'editFilterScript' })}
                 type={ElementType.FILTER}
             />
-            <ExplicitNamingCreationDialog
+            <ExplicitNamingFilterCreationDialog
                 id={currentExplicitNamingFilterId}
                 open={openEditExplicitNamingFilterDialog}
                 onClose={handleCloseExplicitNamingFilterDialog}
@@ -806,7 +809,7 @@ const DirectoryContent = () => {
             <CriteriaBasedFilterDialog
                 id={currentCriteriaBasedFilterId}
                 open={openCriteriaBasedFilterDialog}
-                onClose={handleCloseGenericFilterDialog}
+                onClose={handleCloseCriteriaBasedFilterDialog}
                 onError={handleError}
                 title={useIntl().formatMessage({ id: 'editFilter' })}
                 contentType={ElementType.FILTER}

--- a/src/components/menus/content-contextual-menu.js
+++ b/src/components/menus/content-contextual-menu.js
@@ -23,7 +23,7 @@ import DeleteDialog from '../dialogs/delete-dialog';
 import ScriptDialog from '../dialogs/script-dialog';
 import ReplaceWithScriptDialog from '../dialogs/replace-with-script-dialog';
 import CopyToScriptDialog from '../dialogs/copy-to-script-dialog';
-import GenericFilterDialog from '../dialogs/criteria-filter-dialog';
+import CriteriaBasedFilterDialog from '../dialogs/criteria-based-filter-dialog';
 import CreateStudyDialog from '../dialogs/create-study-dialog';
 
 import { DialogsId } from '../../utils/UIconstants';
@@ -576,7 +576,7 @@ const ContentContextualMenu = (props) => {
                 }}
                 items={selectedElements}
             />
-            <GenericFilterDialog
+            <CriteriaBasedFilterDialog
                 id={getActiveContingencyFormId()}
                 open={openDialog === DialogsId.FILTERS_CONTINGENCY}
                 onClose={handleCloseDialog}
@@ -658,7 +658,7 @@ const ContentContextualMenu = (props) => {
                 currentName={activeElement ? activeElement.elementName : ''}
                 title={useIntl().formatMessage({ id: 'copyToScriptList' })}
             />
-            <GenericFilterDialog
+            <CriteriaBasedFilterDialog
                 id={getActiveFilterFormId()}
                 open={openDialog === DialogsId.GENERIC_FILTER}
                 onClose={handleCloseDialog}


### PR DESCRIPTION
* Fix GenericFilterDialog imported name which was still used and handleCloseGenericFilterDialog replaced by handleCloseCriteriaBasedFilterDialog 
* Rename ExplicitNamingCreationDialog to ExplicitNamingFilterCreationDialog 
* Rename files criteria-filter-* to criteria-based-filter-* to match component name as usual

Some typos from #172 

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>