### PR TITLE
[WIP] Fix create study from DIE with all extensions

### DIFF
--- a/src/components/dialogs/create-study-dialog.js
+++ b/src/components/dialogs/create-study-dialog.js
@@ -136,20 +136,16 @@ const DIE_SUPPORTED_EXTENSIONS = [
     'apc',
     'bbsp',
     'bs',
-    'cm',
     'cp',
     'gs',
     'gsc',
+    'gec',
     'hapc',
     'hopr',
-    'io',
     'isc',
     'ld',
-    'oa',
     'rmd',
     'sa',
-    'soc',
-    'vr',
 ];
 
 /**
@@ -450,7 +446,9 @@ export const CreateStudyDialog = ({ open, onClose, providedCase }) => {
             currentParameters[DIE_EXTENSIONS_PARAM] &&
             currentParameters[DIE_EXTENSIONS_PARAM].indexOf('all') !== -1
         ) {
-            currentParameters[DIE_EXTENSIONS_PARAM] = DIE_SUPPORTED_EXTENSIONS;
+            currentParameters[DIE_EXTENSIONS_PARAM] = formatWithParameters
+                .find((val) => val.name === DIE_EXTENSIONS_PARAM)
+                ?.possibleValues.filter((extension) => extension !== 'all');
         }
 
         const uploadingStudy = {

--- a/src/components/dialogs/create-study-dialog.js
+++ b/src/components/dialogs/create-study-dialog.js
@@ -144,7 +144,6 @@ const DIE_SUPPORTED_EXTENSIONS = [
     'hopr',
     'isc',
     'ld',
-    'rmd',
     'sa',
 ];
 

--- a/src/components/dialogs/create-study-dialog.js
+++ b/src/components/dialogs/create-study-dialog.js
@@ -254,7 +254,7 @@ export const CreateStudyDialog = ({ open, onClose, providedCase }) => {
                             a.localeCompare(b)
                         );
 
-                        //TODO This is temporary fix, we extract the supported extension and ignore the others for DIE files
+                        //TODO This is temporary fix, we filter non supported extensions when we import DIE
                         // When all extensions are supported, it should be removed
                         if (
                             result?.formatName === 'DIE' &&

--- a/src/components/dialogs/create-study-dialog.js
+++ b/src/components/dialogs/create-study-dialog.js
@@ -446,9 +446,6 @@ export const CreateStudyDialog = ({ open, onClose, providedCase }) => {
             return;
         }
 
-        console.log('params : ', formatWithParameters);
-        console.log('params curr : ', currentParameters);
-
         if (
             currentParameters[DIE_EXTENSIONS_PARAM] &&
             currentParameters[DIE_EXTENSIONS_PARAM].indexOf('all') !== -1

--- a/src/components/dialogs/create-study-dialog.js
+++ b/src/components/dialogs/create-study-dialog.js
@@ -255,7 +255,7 @@ export const CreateStudyDialog = ({ open, onClose, providedCase }) => {
                         );
 
                         //TODO This is temporary fix, we filter non supported extensions when we import DIE
-                        // When all extensions are supported, it should be removed
+                        // When all extensions are supported, this should be removed
                         if (
                             result?.formatName === 'DIE' &&
                             p.name === DIE_EXTENSIONS_PARAM


### PR DESCRIPTION
For the moment, we will add only the supported extensions when creating a study from Arcade. When user select "all" in the extension parameter (in Import parameters) we send all the supported extensions.