### PR TITLE
Fix unmount of CreateStudyDialog

### DIFF
--- a/src/components/dialogs/create-case-dialog.js
+++ b/src/components/dialogs/create-case-dialog.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
@@ -40,14 +40,12 @@ export function CreateCaseDialog({ onClose, open }) {
     const activeDirectory = useSelector((state) => state.activeDirectory);
     const userId = useSelector((state) => state.user.profile.sub);
     const dispatch = useDispatch();
-    const [triggerReset, setTriggerReset] = useState(true);
     const [name, NameField, nameError, nameOk, setCaseName, touched] =
         useNameField({
             label: 'nameProperty',
             autoFocus: true,
             elementType: ElementType.CASE,
             parentDirectoryId: activeDirectory,
-            triggerReset,
             active: open,
             style: {
                 width: '90%',
@@ -56,14 +54,12 @@ export function CreateCaseDialog({ onClose, open }) {
 
     const [description, DescriptionField] = useTextValue({
         label: 'descriptionProperty',
-        triggerReset,
         style: {
             width: '90%',
         },
     });
-    const [file, FileField, fileError, isFileOk] = useFileValue({
+    const [file, FileField, fileError, isFileOk, resetFile] = useFileValue({
         label: 'Case',
-        triggerReset,
     });
 
     function validate() {
@@ -134,7 +130,7 @@ export function CreateCaseDialog({ onClose, open }) {
     };
 
     const handleCloseDialog = () => {
-        setTriggerReset((oldVal) => !oldVal);
+        resetFile();
         onClose();
     };
 

--- a/src/components/dialogs/create-study-dialog.js
+++ b/src/components/dialogs/create-study-dialog.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import makeStyles from '@mui/styles/makeStyles';
 import CheckIcon from '@mui/icons-material/Check';
@@ -154,6 +154,8 @@ export const CreateStudyDialog = ({ open, onClose, providedExistingCase }) => {
 
     const [tempCaseUuid, setTempCaseUuid] = useState(null);
 
+    const oldTempCaseUuid = useRef(null);
+
     const [folderSelectorOpen, setFolderSelectorOpen] = useState(false);
     const [activeDirectoryName, setActiveDirectoryName] = useState(null);
 
@@ -265,6 +267,19 @@ export const CreateStudyDialog = ({ open, onClose, providedExistingCase }) => {
             setTempCaseUuid(null);
         }
     }, [open]);
+
+    useEffect(() => {
+        if (oldTempCaseUuid.current !== tempCaseUuid) {
+            if (oldTempCaseUuid.current) {
+                deleteCase(oldTempCaseUuid.current)
+                    .then()
+                    .catch((error) =>
+                        handleFileUploadError(error, setCreateStudyErr)
+                    );
+            }
+            oldTempCaseUuid.current = tempCaseUuid;
+        }
+    }, [tempCaseUuid, handleFileUploadError]);
 
     usePrefillNameField({
         nameRef: studyNameRef,

--- a/src/components/dialogs/field-hook.js
+++ b/src/components/dialogs/field-hook.js
@@ -102,10 +102,7 @@ export const useTextValue = ({
     return [value, field, setValue, hasChanged];
 };
 
-export const useFileValue = ({
-    fileExceedsLimitMessage,
-    isLoading,
-}) => {
+export const useFileValue = ({ fileExceedsLimitMessage, isLoading }) => {
     const selectedFile = useSelector((state) => state.selectedFile);
     const intl = useIntl();
     const dispatch = useDispatch();
@@ -145,7 +142,14 @@ export const useFileValue = ({
             setFileOk(false);
         }
     }, [selectedFile, fileExceedsLimitMessage, intl]);
-    return [selectedFile, field, fileError, fileOk, setFileOk, resetSelectedFile];
+    return [
+        selectedFile,
+        field,
+        fileError,
+        fileOk,
+        setFileOk,
+        resetSelectedFile,
+    ];
 };
 
 const makeAdornmentEndIcon = (content) => {

--- a/src/components/dialogs/field-hook.js
+++ b/src/components/dialogs/field-hook.js
@@ -103,7 +103,6 @@ export const useTextValue = ({
 };
 
 export const useFileValue = ({
-    triggerReset,
     fileExceedsLimitMessage,
     isLoading,
 }) => {
@@ -114,9 +113,11 @@ export const useFileValue = ({
     const [fileError, setFileError] = useState();
 
     const field = <UploadCase isLoading={isLoading} />;
-    useEffect(() => {
-        dispatch(removeSelectedFile());
-    }, [dispatch, triggerReset]);
+
+    const resetSelectedFile = useCallback(
+        () => dispatch(removeSelectedFile()),
+        [dispatch]
+    );
 
     useEffect(() => {
         const MAX_FILE_SIZE_IN_MO = 100;
@@ -144,7 +145,7 @@ export const useFileValue = ({
             setFileOk(false);
         }
     }, [selectedFile, fileExceedsLimitMessage, intl]);
-    return [selectedFile, field, fileError, fileOk, setFileOk];
+    return [selectedFile, field, fileError, fileOk, setFileOk, resetSelectedFile];
 };
 
 const makeAdornmentEndIcon = (content) => {


### PR DESCRIPTION
Since we unmount dialogs instead of hiding them, some useEffect didn't work anymore.
Fix : delete the case created for a study if we cancel its creation + double creation of the case when we open the dialog again.
Remove the useEffect of useFileValue and use a callback instead

Signed-off-by: Florent MILLOT <millotflo@gmail.com>