### PR TITLE
[DO_NOT_MERGE] WIP Fixes filters' popup confirmation Enter keypress

### DIFF
--- a/src/components/dialogs/create-filter-dialog.js
+++ b/src/components/dialogs/create-filter-dialog.js
@@ -51,17 +51,22 @@ const useStyles = makeStyles((theme) => ({
 
 export const renderPopup = (
     isConfirmationPopupOpen,
-    handleKeyPressed,
     intl,
     setOpenConfirmationPopup,
     handlePopupConfirmation
 ) => {
+    const handleEnterKeyPress = (event) => {
+        if (event.key === 'Enter') {
+            handlePopupConfirmation();
+        }
+    };
+
     return (
         <div>
             <Dialog
                 open={isConfirmationPopupOpen}
                 aria-labelledby="dialog-title-change-equipment-type"
-                onKeyPress={handleKeyPressed}
+                onKeyPress={handleEnterKeyPress}
             >
                 <DialogTitle id={'dialog-title-change-equipment-type'}>
                     {'Confirmation'}
@@ -277,12 +282,6 @@ const CreateFilterDialog = ({
         );
     };
 
-    const handleKeyPressed = (event) => {
-        if (event.key === 'Enter') {
-            handleValidation();
-        }
-    };
-
     const onFilterTypeChange = (event) => {
         if (equipmentType !== null) {
             setOpenConfirmationPopup(true);
@@ -307,7 +306,6 @@ const CreateFilterDialog = ({
                 fullWidth={true}
                 open={open && !filterType}
                 onClose={handleClose}
-                onKeyPress={handleKeyPressed}
             >
                 <DialogTitle>{title}</DialogTitle>
                 <DialogContent style={{ maxHeight: '60vh' }}>
@@ -387,7 +385,6 @@ const CreateFilterDialog = ({
             </Dialog>
             {renderPopup(
                 isConfirmationPopupOpen,
-                handleKeyPressed,
                 intl,
                 setOpenConfirmationPopup,
                 handlePopupConfirmation

--- a/src/components/dialogs/criteria-based-filter-dialog-content.js
+++ b/src/components/dialogs/criteria-based-filter-dialog-content.js
@@ -234,12 +234,6 @@ export const CriteriaBasedFilterDialogContent = ({
         handleSelectionEquipmentTypeChange(newEquipmentType);
     };
 
-    const handleKeyPressed = (event) => {
-        if (open && event.key === 'Enter') {
-            handlePopupConfirmation();
-        }
-    };
-
     const renderFilter = (key, definition) => {
         if (initialFilter !== null) {
             if (currentFormEdit[key] === undefined) {
@@ -284,7 +278,6 @@ export const CriteriaBasedFilterDialogContent = ({
                 {renderSpecific()}
                 {renderPopup(
                     isConfirmationPopupOpen,
-                    handleKeyPressed,
                     intl,
                     setOpenConfirmationPopup,
                     handlePopupConfirmation

--- a/src/components/dialogs/explicit-naming-filter-dialog-content.js
+++ b/src/components/dialogs/explicit-naming-filter-dialog-content.js
@@ -218,12 +218,6 @@ const ExplicitNamingFilterDialogContent = ({
         }
     };
 
-    const handleKeyPressed = (event) => {
-        if (open && event.key === 'Enter') {
-            handlePopupConfirmation();
-        }
-    };
-
     const handlePopupConfirmation = () => {
         setOpenConfirmationPopup(false);
         setIsEdited(false);
@@ -281,7 +275,6 @@ const ExplicitNamingFilterDialogContent = ({
             )}
             {renderPopup(
                 isConfirmationPopupOpen,
-                handleKeyPressed,
                 intl,
                 setOpenConfirmationPopup,
                 handlePopupConfirmation


### PR DESCRIPTION
Fixes the inconsistent behavior when pressing the Enter key with the filter's confirmation popups. Now, the behavior is the same as clicking on the Validate button.
