### PR TITLE
filters forms: add a space between filter name and filter type

### DIFF
--- a/src/components/dialogs/commons/criteria-based/criteria-based-form.js
+++ b/src/components/dialogs/commons/criteria-based/criteria-based-form.js
@@ -45,7 +45,7 @@ const CriteriaBasedForm = ({ equipments, defaultValues }) => {
     );
 
     return (
-        <Grid container item spacing={2}>
+        <Grid container item spacing={2} marginTop={'-4px'}>
             {gridItem(equipmentTypeSelectionField, 12)}
             {watchEquipmentType &&
                 equipments[watchEquipmentType].fields.map(

--- a/src/components/dialogs/filter/explicit-naming-filter-form.tsx
+++ b/src/components/dialogs/filter/explicit-naming-filter-form.tsx
@@ -174,7 +174,7 @@ function ExplicitNamingFilterForm() {
     };
 
     return (
-        <Grid container item spacing={2}>
+        <Grid container item spacing={2} marginTop={'-4px'}>
             <Grid item xs={12}>
                 <InputWithPopupConfirmation
                     Input={SelectInput}


### PR DESCRIPTION
no need this PR anymore (fixed it in https://github.com/gridsuite/gridexplore-app/pull/279)