### PR TITLE
Fix LCC converter station CSS in SLD

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -92,7 +92,7 @@ code {
 .sld-busbreaker-connection {
     stroke-width: 4;
 }
-.sld-vsc {
+.sld-vsc, .sld-lcc {
     font-size: 7.43px;
 }
 .sld-grid {


### PR DESCRIPTION
Fix LCC converter station CSS after powsybl migration. LCC_CONVERTER_STATION were introduced in powsybl-diagram by https://github.com/powsybl/powsybl-diagram/pull/537.