### PR TITLE
improve httpd caching configuration (etags, cache-control)

### DIFF
--- a/app-httpd.conf
+++ b/app-httpd.conf
@@ -9,9 +9,41 @@
     LoadModule info_module modules/mod_info.so
 
     DocumentRoot /opt/bitnami/apache/htdocs/gridexplore/
-    AddOutputFilterByType INCLUDES text/html
+
     <Directory /opt/bitnami/apache/htdocs/gridexplore/>
+        <Files "index.html">
+          SetOutputFilter INCLUDES
+        </Files>
+        <FilesMatch "^(env\.json|idpSettings\.json)$">
+          # FileETag Digest for stable Etags accross loadbalanced servers for mounted files.
+          #   "FileETag Digest" is acceptable here because these are only small files so
+          #   having to read the full content of the file instead of just the filesystem
+          #   metadata is not prohibitedly expensive. A better alternative would be to find
+          #   a way to have stable filesystem metadata on all servers because:
+          #   - accessing file system metadata is a lot less expensive.
+          #   - contrary to apache httpd, nginx doesn't have an option to change the ETag
+          #     generation method and always uses the filesystem metadata (size, mtime),
+          #     so using "FileEtag Digest" locks us in with apache httpd.
+          #   NOTE: this doesn't apply to files in the image (their filesystem metadata
+          #   is the same because it's from the image), only to mounted files (bind mount
+          #   or volume mount in docker compose, configmap in kubernetes)
+          #   NOTE2: Because we use single file bind mounts for our files, the contents
+          #   and filesystem metadata of our files fall out of sync between the host and
+          #   the containers when the file is deleted or replaced (more precisely, as
+          #   soon as the inode number of the file changes) (this can happen quite silently
+          #   if your editor replaces the file when saving), but this means using Digest doesn't
+          #   solve this issue. This is a known docker limitation: https://github.com/moby/moby/issues/6011
+          FileETag Digest
+        </FilesMatch>
         Options +Includes
+        Header set Cache-Control "no-cache"
+    </Directory>
+
+    <Directory /opt/bitnami/apache/htdocs/gridexplore/static/>
+        # All files in this folder are public and have in their name
+        # the hash of their content, so cache them very aggressively
+        # as per recommended best practices
+        Header set Cache-Control "public, max-age=31536000, immutable"
     </Directory>
 
     <Location "/actuator/info">


### PR DESCRIPTION
- add cache-control no-cache to force revalidation on all files with static names
- add cache-control "max-age=31536000, immutable" to all files with hash in their names
- restore etags on all files except index.html (index.html uses SSI)
- add FileEtags Digest on mounted files (env.json, idpSettings.json)