### PR TITLE
Remove warning "any return type"

### DIFF
--- a/src/components/dialogs/filter/expert/expert-filter-utils.ts
+++ b/src/components/dialogs/filter/expert/expert-filter-utils.ts
@@ -290,7 +290,10 @@ export const queryValidator: QueryValidator = (query) => {
 };
 
 // Remove a rule or group and its parents if they become empty
-export function recursiveRemove(query: RuleGroupTypeAny, path: number[]): any {
+export function recursiveRemove(
+    query: RuleGroupTypeAny,
+    path: number[]
+): RuleGroupTypeAny {
     // If it's an only child, we also need to remove and check the parent group (but not the root)
     if (
         getNumberOfSiblings(path, query) === 1 &&

--- a/src/components/dialogs/filter/expert/expert-filter-utils.ts
+++ b/src/components/dialogs/filter/expert/expert-filter-utils.ts
@@ -296,11 +296,10 @@ export function recursiveRemove(query: RuleGroupTypeAny, path: number[]) {
         getNumberOfSiblings(path, query) === 1 &&
         path.toString() !== [0].toString()
     ) {
-        return recursiveRemove(query, getParentPath(path));
-    }
-    // Otherwise, we can safely remove it
-    else {
-        return remove(query, path);
+        recursiveRemove(query, getParentPath(path));
+    } else {
+        // Otherwise, we can safely remove it
+        remove(query, path);
     }
 }
 

--- a/src/components/dialogs/filter/expert/expert-filter-utils.ts
+++ b/src/components/dialogs/filter/expert/expert-filter-utils.ts
@@ -290,16 +290,17 @@ export const queryValidator: QueryValidator = (query) => {
 };
 
 // Remove a rule or group and its parents if they become empty
-export function recursiveRemove(query: RuleGroupTypeAny, path: number[]) {
+export function recursiveRemove(query: RuleGroupTypeAny, path: number[]): any {
     // If it's an only child, we also need to remove and check the parent group (but not the root)
     if (
         getNumberOfSiblings(path, query) === 1 &&
         path.toString() !== [0].toString()
     ) {
-        recursiveRemove(query, getParentPath(path));
-    } else {
-        // Otherwise, we can safely remove it
-        remove(query, path);
+        return recursiveRemove(query, getParentPath(path));
+    }
+    // Otherwise, we can safely remove it
+    else {
+        return remove(query, path);
     }
 }
 


### PR DESCRIPTION
TS7023:  `recursiveRemove`  implicitly has return type  `any`  because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.