### PR TITLE
Make case_format optional in createStudyDialogFormValidationSchema

### DIFF
--- a/src/components/dialogs/create-study-dialog/create-study-dialog-utils.js
+++ b/src/components/dialogs/create-study-dialog/create-study-dialog-utils.js
@@ -36,5 +36,5 @@ export const createStudyDialogFormValidationSchema = yup.object().shape({
     [CASE_UUID]: yup.string().required(),
     [CASE_FILE]: yup.mixed().nullable().required(),
     [DIRECTORY]: yup.string().required(),
-    [CASE_FORMAT]: yup.string().required(),
+    [CASE_FORMAT]: yup.string().optional(),
 });


### PR DESCRIPTION
Update createStudyDialogFormValidationSchema to make the `case_format` field optional instead of required. This change allows users to validate the form without being blocked by the `case_format` field.