### PR TITLE
Update commons-ui to version 0.57

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.11.4",
                 "@emotion/styled": "^11.11.5",
-                "@gridsuite/commons-ui": "0.56.0",
+                "@gridsuite/commons-ui": "0.57.0",
                 "@hookform/resolvers": "^3.3.4",
                 "@mui/icons-material": "^5.15.14",
                 "@mui/lab": "5.0.0-alpha.169",
@@ -2760,12 +2760,12 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.56.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.56.0.tgz",
-            "integrity": "sha512-c2QcYLZQQFS6tGOaNV6+smBNRPsMpOHxPZoB9bOhqth1kMlcv5Q30KkMrsWXutPXCxTApb6/+Ok/QOqTemh/jQ==",
+            "version": "0.57.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.57.0.tgz",
+            "integrity": "sha512-OkaUmjoNAK/g79Hc+0PajVF+nJro+uxGXr032Ar9zcDurT3emOcn+VvenQszb7Brl+9ZAUfRKMsmvUL8aiu/aw==",
             "dependencies": {
-                "@react-querybuilder/dnd": "^6.5.5",
-                "@react-querybuilder/material": "^6.5.5",
+                "@react-querybuilder/dnd": "^7.2.0",
+                "@react-querybuilder/material": "^7.2.0",
                 "autosuggest-highlight": "^3.3.4",
                 "clsx": "^2.1.0",
                 "jwt-decode": "^4.0.0",
@@ -2776,8 +2776,7 @@
                 "react-csv-downloader": "^3.1.0",
                 "react-dnd": "^16.0.1",
                 "react-dnd-html5-backend": "^16.0.1",
-                "react-querybuilder": "^6.5.1",
-                "react-request-fullscreen": "^1.1.2",
+                "react-querybuilder": "^7.2.0",
                 "react-virtualized": "^9.22.5",
                 "uuid": "^9.0.1"
             },
@@ -4188,27 +4187,27 @@
             "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
         },
         "node_modules/@react-querybuilder/dnd": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/@react-querybuilder/dnd/-/dnd-6.5.5.tgz",
-            "integrity": "sha512-aZBkWEXN53W81Ho+mvg+xJcZNkPlhr1LmAMOjQU9fite8hhr7JTo5i8rSZmCwmoE0REBdT/xowsUJ17dDhTGWg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@react-querybuilder/dnd/-/dnd-7.2.0.tgz",
+            "integrity": "sha512-1MdjH87SQtL3twyhPYfLa7iyzqi+cmTR3XNmBFQwqBl201sYDwvJ5/+SyIuLFcPsLIjSDJiXT2IJc8Y9f7epUQ==",
             "peerDependencies": {
-                "react": ">=16.8.0",
+                "react": ">=18",
                 "react-dnd": ">=14.0.0",
                 "react-dnd-html5-backend": ">=14.0.0",
-                "react-querybuilder": "^6.5.5"
+                "react-querybuilder": "^7.2.0"
             }
         },
         "node_modules/@react-querybuilder/material": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/@react-querybuilder/material/-/material-6.5.5.tgz",
-            "integrity": "sha512-MDhB0s1ENsT5K2Z42/q4IWDQiqnPzjxOsU4LqpxI8Fn90SBJdIm5vnsUCtJm8W69mAsY29SmC98IyrKsy+RzNQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@react-querybuilder/material/-/material-7.2.0.tgz",
+            "integrity": "sha512-5WA5UdE5lwJNh3QoSdbKzhUsQYVuWIcN2qngY66J7MFhFl7Ggwd/kNaUIR1y2yRJ3DDvGGL66MsuDVzMuwp2nw==",
             "peerDependencies": {
                 "@emotion/react": "^11",
                 "@emotion/styled": "^11",
                 "@mui/icons-material": ">=5.0.0",
                 "@mui/material": ">=5.0.0",
-                "react": ">=16.8.0",
-                "react-querybuilder": "^6.5.5"
+                "react": ">=18",
+                "react-querybuilder": "^7.2.0"
             }
         },
         "node_modules/@reduxjs/toolkit": {
@@ -13902,6 +13901,14 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/numeric-quantity": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/numeric-quantity/-/numeric-quantity-2.0.1.tgz",
+            "integrity": "sha512-+Bt2X6YxM5bg8XIBl76NVeG2eL0Y5VQRoyz6GLYrZXW/TDh7We+tGeX4/WZWhaVGOg5ZjNBEOZt9a86slMhOJA==",
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/nwsapi": {
             "version": "2.2.7",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
@@ -16384,15 +16391,18 @@
             }
         },
         "node_modules/react-querybuilder": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/react-querybuilder/-/react-querybuilder-6.5.5.tgz",
-            "integrity": "sha512-i/MG1+XMmAaaVtdbyw5Pubxz3auwD6R2u9hfhskksniI1yuvJoyraF3mVeVgPQHPU9hM7H2HyVL8PxYUvsHZcg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/react-querybuilder/-/react-querybuilder-7.2.0.tgz",
+            "integrity": "sha512-66MtxaA+ogLnFzU4oztvJbI6t8/JM37X433QC40ff3190MblN6GTupmMHpnGPckiwH3sUVAqaXptR4b466TE4w==",
             "dependencies": {
-                "clsx": "^2.0.0",
-                "immer": "^10.0.3"
+                "@reduxjs/toolkit": "^2.2.2",
+                "clsx": "^2.1.0",
+                "immer": "^10.0.4",
+                "numeric-quantity": "^2.0.1",
+                "react-redux": "^9.1.0"
             },
             "peerDependencies": {
-                "react": ">=16.8.0"
+                "react": ">=18"
             }
         },
         "node_modules/react-querybuilder/node_modules/clsx": {
@@ -16436,11 +16446,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/react-request-fullscreen": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/react-request-fullscreen/-/react-request-fullscreen-1.1.2.tgz",
-            "integrity": "sha512-WsQ/htbZag9qNfWPb2fEm0if+oUsRK3rTKKJ007n64Mk0PY82gAbLwVKZ+7OmzkHm6f/PSkxf8pdYlzBUmXR/Q=="
         },
         "node_modules/react-router": {
             "version": "6.22.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@gridsuite/commons-ui": "0.56.0",
+        "@gridsuite/commons-ui": "0.57.0",
         "@hookform/resolvers": "^3.3.4",
         "@mui/icons-material": "^5.15.14",
         "@mui/lab": "5.0.0-alpha.169",

--- a/src/components/app-wrapper.js
+++ b/src/components/app-wrapper.js
@@ -36,6 +36,8 @@ import {
     directory_items_input_en,
     element_search_fr,
     element_search_en,
+    filter_fr,
+    filter_en,
 } from '@gridsuite/commons-ui';
 import { IntlProvider } from 'react-intl';
 import { BrowserRouter } from 'react-router-dom';
@@ -187,6 +189,7 @@ const messages = {
         ...backend_locale_en,
         ...directory_items_input_en,
         ...element_search_en,
+        ...filter_en,
         ...messages_plugins_en, // keep it at the end to allow translation overwritting
     },
     fr: {
@@ -205,6 +208,7 @@ const messages = {
         ...element_search_fr,
         ...aggrid_locale_fr, // Only the french locale is needed
         ...directory_items_input_fr,
+        ...filter_fr,
         ...messages_plugins_fr, // keep it at the end to allow translation overwritting
     },
 };


### PR DESCRIPTION
Updated package-lock.json and package.json to use version 0.57.0 of @gridsuite/commons-ui. Updated dependencies accordingly.
Add import of filter translations.