### PR TITLE
Add context menu to content toolbar

### DIFF
--- a/src/components/directory-content.jsx
+++ b/src/components/directory-content.jsx
@@ -668,12 +668,16 @@ const DirectoryContent = () => {
 
     return (
         <>
-            {rows && (
-                <ContentToolbar
-                    selectedElements={checkedRows}
-                    onContextMenu={onContextMenu}
-                />
-            )}
+            {
+                //ContentToolbar needs to be outside the DirectoryContentTable container otherwise it
+                //creates a visual offset rendering the last elements of a full table inaccessible
+                rows && (
+                    <ContentToolbar
+                        selectedElements={checkedRows}
+                        onContextMenu={onContextMenu}
+                    />
+                )
+            }
             <Grid xs={12} onContextMenu={onContextMenu}>
                 {renderContent()}
             </Grid>

--- a/src/components/directory-content.jsx
+++ b/src/components/directory-content.jsx
@@ -668,7 +668,12 @@ const DirectoryContent = () => {
 
     return (
         <>
-            {rows && <ContentToolbar selectedElements={checkedRows} />}
+            {rows && (
+                <ContentToolbar
+                    selectedElements={checkedRows}
+                    onContextMenu={onContextMenu}
+                />
+            )}
             <Grid xs={12} onContextMenu={onContextMenu}>
                 {renderContent()}
             </Grid>


### PR DESCRIPTION
Ideally I'd have added `<ContentToolbar>` to the same container as the one where the table is rendered so the parent container could handle the context menu event instead of duplicating it. 

Unfortunately doing so makes it so AG Grid think the content toolbar is part of the table and thus crops out the lower part of the table itself, looks like a bug, the issue is noticeable in folders where its elements take the whole screen, its latest element won't be accessible 