### PR TITLE
Fix ag grid chips to get the right value from RHF

### DIFF
--- a/src/components/utils/rhf-inputs/ag-grid-table-rhf/cell-editors/chips-array-editor.jsx
+++ b/src/components/utils/rhf-inputs/ag-grid-table-rhf/cell-editors/chips-array-editor.jsx
@@ -7,11 +7,23 @@
 
 import { forwardRef } from 'react';
 import TableCellWrapper from './table-cell-wrapper';
-import { MultipleAutocompleteInput } from '@gridsuite/commons-ui';
+import { useFormContext } from 'react-hook-form';
+import { FieldConstants, MultipleAutocompleteInput } from '@gridsuite/commons-ui';
 
 const ChipsArrayEditor = forwardRef(({ ...props }, ref) => {
     const { name, node, colDef } = props;
-    const cellName = `${name}.${node.rowIndex}.${colDef.field}`;
+    const { getValues } = useFormContext();
+
+    const getIndexInFormData = (nodeData) => {
+        return getValues(name).findIndex(
+            (row) =>
+                row[FieldConstants.AG_GRID_ROW_UUID] ===
+                nodeData[FieldConstants.AG_GRID_ROW_UUID]
+        );
+    };
+
+    const cellName = `${name}.${getIndexInFormData(node.data)}.${colDef.field}`;
+
     return (
         <TableCellWrapper agGridRef={ref} name={cellName}>
             <MultipleAutocompleteInput

--- a/src/components/utils/rhf-inputs/ag-grid-table-rhf/cell-editors/chips-array-editor.jsx
+++ b/src/components/utils/rhf-inputs/ag-grid-table-rhf/cell-editors/chips-array-editor.jsx
@@ -8,7 +8,10 @@
 import { forwardRef } from 'react';
 import TableCellWrapper from './table-cell-wrapper';
 import { useFormContext } from 'react-hook-form';
-import { FieldConstants, MultipleAutocompleteInput } from '@gridsuite/commons-ui';
+import {
+    FieldConstants,
+    MultipleAutocompleteInput,
+} from '@gridsuite/commons-ui';
 
 const ChipsArrayEditor = forwardRef(({ ...props }, ref) => {
     const { name, node, colDef } = props;


### PR DESCRIPTION
**Issue**:
The current implementation of ChipsArrayEditor does not render the correct chip values when sorting is applied in AG Grid. This happens because the row index used to fetch values from React Hook Form (RHF) becomes inaccurate after sorting, leading to incorrect data being displayed.

**Fix**:
In this PR, we have addressed the issue by ensuring that the correct row index is fetched based on the unique identifier 'AG_GRID_ROW_UUID'. This change guarantees that the ChipsArrayEditor component retrieves the correct values from RHF, even after sorting is applied.