### PR TITLE
Fix directory table sorting on type

### DIFF
--- a/src/components/utils/renderers/type-cell-renderer.tsx
+++ b/src/components/utils/renderers/type-cell-renderer.tsx
@@ -13,7 +13,7 @@ import { IntlShape, useIntl } from 'react-intl';
 import { UUID } from 'crypto';
 import { Box } from '@mui/material';
 
-const getElementTypeTranslation = (
+export const getElementTypeTranslation = (
     type: ElementType,
     subtype: string | null,
     formatCase: string | null,


### PR DESCRIPTION
In this PR, we address two issues related to sorting in the directory table:

1.**Fixed Sorting on Type Column**: We implemented a custom comparator for the type column. This comparator translates the type values before sorting to ensure accurate and meaningful sorting based on the translated values.

2. **Disabled Sorting on Description Column**: We disabled sorting on the description column due to its inaccuracy, ensuring that users are not misled by incorrect sorting results.