### PR TITLE
Update commons-ui version to use 0.60.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.11.4",
                 "@emotion/styled": "^11.11.5",
-                "@gridsuite/commons-ui": "0.60.1",
+                "@gridsuite/commons-ui": "0.60.2",
                 "@hookform/resolvers": "^3.3.4",
                 "@mui/icons-material": "^5.15.14",
                 "@mui/lab": "5.0.0-alpha.169",
@@ -2955,9 +2955,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.60.1",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.60.1.tgz",
-            "integrity": "sha512-p7jpg+TESVmoeuA5bskVmisVynHmEM0Ic6uVqlzrBGaaoSEmwrT+Az2d8vSYGPRS0rW7iOeffeU5ma9Gh52AaA==",
+            "version": "0.60.2",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.60.2.tgz",
+            "integrity": "sha512-dvbKIFjCkN6bgAY1dQN++O+k5aEEMOFwzaAXvskvpOoDdOePvFQSoFJLyf/rn+I/gUo5A8JysSd2MygQzlagaA==",
             "dependencies": {
                 "@react-querybuilder/dnd": "^7.2.0",
                 "@react-querybuilder/material": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@gridsuite/commons-ui": "0.60.1",
+        "@gridsuite/commons-ui": "0.60.2",
         "@hookform/resolvers": "^3.3.4",
         "@mui/icons-material": "^5.15.14",
         "@mui/lab": "5.0.0-alpha.169",


### PR DESCRIPTION
Updated package-lock.json and package.json to use version 0.60.2 of @gridsuite/commons-ui.
Fix substation property label 