### PR TITLE
Fix Elements rename error

### DIFF
--- a/src/components/directory-content.jsx
+++ b/src/components/directory-content.jsx
@@ -278,6 +278,11 @@ const DirectoryContent = () => {
         (event) => {
             if (event.data && event.data.uploading !== null) {
                 if (event.data.type !== 'DIRECTORY') {
+                    if (selectedDirectory) {
+                        dispatch(
+                            setActiveDirectory(selectedDirectory.elementUuid)
+                        );
+                    }
                     setActiveElement({
                         hasMetadata:
                             childrenMetadata[event.data.elementUuid] !==
@@ -313,6 +318,8 @@ const DirectoryContent = () => {
             childrenMetadata,
             contextualMixPolicies.BIG,
             contextualMixPolicy,
+            dispatch,
+            selectedDirectory,
         ]
     );
 


### PR DESCRIPTION
fix(): set activeDirectory when opening contextualMenu because it's used for URL making for name valiation on elements

this call was deleted by :
https://github.com/gridsuite/gridexplore-app/commit/f8e8d1bd6669c6a2bedb1138111e732522eed7cc#diff-2ced0887fa0673224dec10bcde11d030ed850b29ec87e8b4038872979b44e108L306-L308 