### PR TITLE
fix flash issue on table element click

### DIFF
--- a/src/components/directory-content-table.tsx
+++ b/src/components/directory-content-table.tsx
@@ -18,7 +18,7 @@ import {
     AgGridEvent,
     GetRowIdParams,
 } from 'ag-grid-community';
-import { RefObject } from 'react';
+import { RefObject, useCallback } from 'react';
 
 interface DirectoryContentTableProps
     extends Pick<
@@ -69,12 +69,15 @@ export const DirectoryContentTable = ({
     onGridReady,
     colDef,
 }: DirectoryContentTableProps) => {
-    const getCustomRowStyle = (cellData: RowClassParams<ElementAttributes>) => {
-        return {
-            ...getClickableRowStyle(cellData),
-            ...getRowStyle?.(cellData),
-        };
-    };
+    const getCustomRowStyle = useCallback(
+        (cellData: RowClassParams<ElementAttributes>) => {
+            return {
+                ...getClickableRowStyle(cellData),
+                ...getRowStyle?.(cellData),
+            };
+        },
+        [getRowStyle]
+    );
 
     return (
         <CustomAGGrid


### PR DESCRIPTION
This PR fixes a glitch that occurs when clicking on a row for the first time in the DirectoryContentTable component. The issue was due to the getCustomRowStyle function not being memoized, causing unnecessary re-renders