### PR TITLE
Fix elements deletion

### DIFF
--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -219,7 +219,7 @@ export function deleteElement(elementUuid) {
 
 export function deleteElements(elementUuids, activeDirectory) {
     console.info('Deleting elements : %s', elementUuids);
-    const idsParams = getRequestParamFromList(elementUuids, 'ids').toString();
+    const idsParams = getRequestParamFromList('ids', elementUuids).toString();
     return backendFetch(
         PREFIX_EXPLORE_SERVER_QUERIES +
             `/v1/explore/elements/` +


### PR DESCRIPTION
since the 0.63.1 version of commons-ui the order of getRequestParamFromList parameters has been changed
which provokes an Uncaught TypeError and the user could not delete elements