### PR TITLE
Name exported file : using a file name map

### DIFF
--- a/src/components/menus/content-contextual-menu.jsx
+++ b/src/components/menus/content-contextual-menu.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
@@ -42,8 +42,8 @@ import {
 import { ContingencyListType, FilterType } from '../../utils/elementType';
 import {
     ElementType,
-    useSnackMessage,
     FilterCreationDialog,
+    useSnackMessage,
 } from '@gridsuite/commons-ui';
 
 import CommonContextualMenu from './common-contextual-menu';
@@ -701,14 +701,7 @@ const ContentContextualMenu = (props) => {
                     <ExportCaseDialog
                         selectedElements={selectedElements}
                         onClose={handleCloseExportDialog}
-                        onExport={(format, formatParameters, fileName) =>
-                            handleConvertCases(
-                                selectedElements,
-                                format,
-                                formatParameters,
-                                fileName
-                            )
-                        }
+                        onExport={handleConvertCases}
                     />
                 );
             case DialogsId.REPLACE_FILTER_BY_SCRIPT_CONTINGENCY:

--- a/src/components/toolbars/content-toolbar.jsx
+++ b/src/components/toolbars/content-toolbar.jsx
@@ -16,9 +16,8 @@ import DriveFileMoveIcon from '@mui/icons-material/DriveFileMove';
 import DeleteDialog from '../dialogs/delete-dialog';
 import CommonToolbar from './common-toolbar';
 import { useMultipleDeferredFetch } from '../../utils/custom-hooks';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { ElementType, useSnackMessage } from '@gridsuite/commons-ui';
 import MoveDialog from '../dialogs/move-dialog';
-import { ElementType } from '@gridsuite/commons-ui';
 import { DownloadForOffline, FileDownload } from '@mui/icons-material';
 import { useDownloadUtils } from '../utils/caseUtils';
 import ExportCaseDialog from '../dialogs/export-case-dialog';
@@ -238,14 +237,7 @@ const ContentToolbar = (props) => {
                     <ExportCaseDialog
                         selectedElements={selectedElements}
                         onClose={handleCloseExportDialog}
-                        onExport={(format, formatParameters, fileName) =>
-                            handleConvertCases(
-                                selectedElements,
-                                format,
-                                formatParameters,
-                                fileName
-                            )
-                        }
+                        onExport={handleConvertCases}
                     />
                 );
             default:


### PR DESCRIPTION
A solution which uses a map between case uuid and file name for each case. This solution is aimed to avoid pass the same fileName for every cases in the hook handleConvertCases