### PR TITLE
Fix: update selected directory's name after renaming

### DIFF
--- a/src/components/directory-content.jsx
+++ b/src/components/directory-content.jsx
@@ -266,9 +266,8 @@ const DirectoryContent = () => {
         (event) => {
             if (event.data && event.data.uploading !== null) {
                 if (event.data.type !== 'DIRECTORY') {
-                    if (selectedDirectory) {
-                        dispatch(setActiveDirectory(selectedDirectory.elementUuid));
-                    }
+                    dispatch(setActiveDirectory(selectedDirectory?.elementUuid));
+
                     setActiveElement({
                         hasMetadata: childrenMetadata[event.data.elementUuid] !== undefined,
                         specificMetadata: childrenMetadata[event.data.elementUuid]?.specificMetadata,
@@ -293,7 +292,14 @@ const DirectoryContent = () => {
                 handleOpenContentMenu(event.event);
             }
         },
-        [checkedRows, childrenMetadata, contextualMixPolicies.BIG, contextualMixPolicy, dispatch, selectedDirectory]
+        [
+            checkedRows,
+            childrenMetadata,
+            contextualMixPolicies.BIG,
+            contextualMixPolicy,
+            dispatch,
+            selectedDirectory?.elementUuid,
+        ]
     );
 
     const onContextMenu = useCallback(
@@ -301,9 +307,8 @@ const DirectoryContent = () => {
             //We check if the context menu was triggered from a row to prevent displaying both the directory and the content context menus
             const isRow = !!event.target.closest(`.${CUSTOM_ROW_CLASS}`);
             if (!isRow) {
-                if (selectedDirectory) {
-                    dispatch(setActiveDirectory(selectedDirectory.elementUuid));
-                }
+                dispatch(setActiveDirectory(selectedDirectory?.elementUuid));
+
                 setMousePosition({
                     mouseX: event.clientX + constants.HORIZONTAL_SHIFT,
                     mouseY: event.clientY + constants.VERTICAL_SHIFT,
@@ -311,7 +316,7 @@ const DirectoryContent = () => {
                 handleOpenDirectoryMenu(event);
             }
         },
-        [dispatch, selectedDirectory]
+        [dispatch, selectedDirectory?.elementUuid]
     );
 
     const handleError = useCallback(
@@ -402,12 +407,12 @@ const DirectoryContent = () => {
     const [openDescModificationDialog, setOpenDescModificationDialog] = useState(false);
 
     useEffect(() => {
-        if (!selectedDirectory) {
+        if (!selectedDirectory?.elementUuid) {
             return;
         }
         setIsMissingDataAfterDirChange(true);
         setCheckedRows([]);
-    }, [selectedDirectory, setIsMissingDataAfterDirChange]);
+    }, [selectedDirectory?.elementUuid, setIsMissingDataAfterDirChange]);
 
     const isActiveElementUnchecked = useMemo(
         () => activeElement && !checkedRows.find((children) => children.elementUuid === activeElement.elementUuid),
@@ -459,11 +464,10 @@ const DirectoryContent = () => {
             //set the contextualMenu position
             setMousePosition(handleMousePosition(coordinates, isEmpty));
             setOpenDirectoryMenu(true);
-            if (selectedDirectory) {
-                dispatch(setActiveDirectory(selectedDirectory.elementUuid));
-            }
+
+            dispatch(setActiveDirectory(selectedDirectory.elementUuid));
         },
-        [dispatch, selectedDirectory, handleMousePosition]
+        [dispatch, selectedDirectory?.elementUuid, handleMousePosition]
     );
 
     const renderEmptyDirContent = () => (

--- a/src/components/tree-views-container.jsx
+++ b/src/components/tree-views-container.jsx
@@ -307,14 +307,6 @@ const TreeViewsContainer = () => {
                 // is deleted by another user
                 // we should select (closest still existing) parent directory
                 dispatch(setSelectedDirectory(treeDataRef.current.mapData[nodeId]));
-            } else {
-                // we must override selectedDirectory because it could be the one to have changed (renamed for example)
-                const updatedSelectedDirectory = newSubdirectories.find(
-                    (n) => n.elementUuid === selectedDirectoryRef.current.elementUuid
-                );
-                if (updatedSelectedDirectory !== undefined) {
-                    dispatch(setSelectedDirectory(updatedSelectedDirectory));
-                }
             }
         },
         [insertContent, dispatch]

--- a/src/components/tree-views-container.jsx
+++ b/src/components/tree-views-container.jsx
@@ -270,7 +270,7 @@ const TreeViewsContainer = () => {
 
     useEffect(() => {
         updatePath(selectedDirectoryRef.current?.elementUuid);
-    }, [treeData.mapData, updatePath, selectedDirectory]);
+    }, [treeData.mapData, updatePath, selectedDirectory?.elementUuid]);
 
     const insertContent = useCallback(
         (nodeId, childrenToBeInserted) => {
@@ -307,9 +307,17 @@ const TreeViewsContainer = () => {
                 // is deleted by another user
                 // we should select (closest still existing) parent directory
                 dispatch(setSelectedDirectory(treeDataRef.current.mapData[nodeId]));
+            } else {
+                // we must override selectedDirectory because it could be the one to have changed (renamed for example)
+                const updatedSelectedDirectory = newSubdirectories.find(
+                    (n) => n.elementUuid === selectedDirectoryRef.current.elementUuid
+                );
+                if (updatedSelectedDirectory !== undefined) {
+                    dispatch(setSelectedDirectory(updatedSelectedDirectory));
+                }
             }
         },
-        [insertContent, selectedDirectoryRef, dispatch]
+        [insertContent, dispatch]
     );
 
     const mergeCurrentAndUploading = useCallback(
@@ -340,7 +348,7 @@ const TreeViewsContainer = () => {
                 }
             }
         },
-        [uploadingElements, selectedDirectoryRef]
+        [uploadingElements]
     );
 
     /* currentChildren management */
@@ -474,18 +482,6 @@ const TreeViewsContainer = () => {
                 ) {
                     dispatch(setSelectedDirectory(null));
                 }
-                if (
-                    notificationTypeH === notificationType.UPDATE_DIRECTORY &&
-                    selectedDirectoryRef.current != null &&
-                    selectedDirectoryRef.current.elementUuid === directoryUuid
-                ) {
-                    dispatch(
-                        setSelectedDirectory({
-                            ...selectedDirectoryRef.current,
-                            elementName: elementName,
-                        })
-                    );
-                }
                 return;
             }
             if (directoryUuid) {
@@ -521,11 +517,11 @@ const TreeViewsContainer = () => {
 
     /* Handle components synchronization */
     useEffect(() => {
-        if (selectedDirectory) {
+        if (selectedDirectory?.elementUuid) {
             console.debug('useEffect over selectedDirectory', selectedDirectory.elementUuid);
             updateDirectoryTreeAndContent(selectedDirectory.elementUuid);
         }
-    }, [selectedDirectory, updateDirectoryTreeAndContent]);
+    }, [selectedDirectory?.elementUuid, updateDirectoryTreeAndContent]);
 
     const getActiveDirectory = () => {
         if (treeDataRef.current.mapData && treeDataRef.current.mapData[activeDirectory]) {

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -292,6 +292,12 @@ export const reducer = createReducer(initialState, (builder) => {
             rootDirectories: filteredTreeDataRootDirectories,
             mapData: filteredTreeDataMapData,
         };
+
+        // we must override selectedDirectory elementName because it could be the one to have changed
+        if (state.selectedDirectory) {
+            state.selectedDirectory.elementName =
+                filteredTreeDataMapData[state.selectedDirectory?.elementUuid].elementName;
+        }
     });
 
     builder.addCase(SELECTION_FOR_COPY, (state, action: SelectionForCopyAction) => {


### PR DESCRIPTION
Avoid every effects elsewhere procs when this object change instead of just its `elementUuid`.