### PR TITLE
Fix error handling for name duplication

### DIFF
--- a/src/components/menus/content-contextual-menu.tsx
+++ b/src/components/menus/content-contextual-menu.tsx
@@ -57,7 +57,7 @@ import ExportCaseDialog from '../dialogs/export-case-dialog';
 import { setSelectionForCopy } from '../../redux/actions';
 import { useParameterState } from '../dialogs/use-parameters-dialog';
 import { PARAM_LANGUAGE } from '../../utils/config-params';
-import { handleMaxElementsExceededError } from '../utils/rest-errors';
+import { handleMaxElementsExceededError, handleNameAlreadyExist } from '../utils/rest-errors';
 import { AppState } from 'redux/reducer';
 import { PopoverPosition, PopoverReference } from '@mui/material';
 
@@ -239,6 +239,9 @@ const ContentContextualMenu = (props: ContentContextualMenuProps) => {
                         if (handleMaxElementsExceededError(error, snackError)) {
                             return;
                         }
+                        if(handleNameAlreadyExist(error, snackError)){
+                            return;
+                        }
                         handleDuplicateError(error.message);
                     });
                     break;
@@ -249,6 +252,9 @@ const ContentContextualMenu = (props: ContentContextualMenuProps) => {
                         activeElement.type,
                         selectedElements[0].specificMetadata.type
                     ).catch((error) => {
+                        if(handleNameAlreadyExist(error, snackError)){
+                            return;
+                        }
                         handleDuplicateError(error.message);
                     });
                     break;
@@ -263,6 +269,9 @@ const ContentContextualMenu = (props: ContentContextualMenuProps) => {
                         ElementType.PARAMETERS,
                         activeElement.type
                     ).catch((error) => {
+                        if(handleNameAlreadyExist(error, snackError)){
+                            return;
+                        }
                         handleDuplicateError(error.message);
                     });
                     break;

--- a/src/components/menus/content-contextual-menu.tsx
+++ b/src/components/menus/content-contextual-menu.tsx
@@ -239,7 +239,7 @@ const ContentContextualMenu = (props: ContentContextualMenuProps) => {
                         if (handleMaxElementsExceededError(error, snackError)) {
                             return;
                         }
-                        if(handleNameAlreadyExist(error, snackError)){
+                        if (handleNameAlreadyExist(error, snackError)) {
                             return;
                         }
                         handleDuplicateError(error.message);
@@ -252,7 +252,7 @@ const ContentContextualMenu = (props: ContentContextualMenuProps) => {
                         activeElement.type,
                         selectedElements[0].specificMetadata.type
                     ).catch((error) => {
-                        if(handleNameAlreadyExist(error, snackError)){
+                        if (handleNameAlreadyExist(error, snackError)) {
                             return;
                         }
                         handleDuplicateError(error.message);
@@ -269,7 +269,7 @@ const ContentContextualMenu = (props: ContentContextualMenuProps) => {
                         ElementType.PARAMETERS,
                         activeElement.type
                     ).catch((error) => {
-                        if(handleNameAlreadyExist(error, snackError)){
+                        if (handleNameAlreadyExist(error, snackError)) {
                             return;
                         }
                         handleDuplicateError(error.message);

--- a/src/components/menus/directory-tree-contextual-menu.tsx
+++ b/src/components/menus/directory-tree-contextual-menu.tsx
@@ -145,7 +145,7 @@ const DirectoryTreeContextualMenu: React.FC<DirectoryTreeContextualMenuProps> = 
                         if (handleMaxElementsExceededError(error, snackError)) {
                             return;
                         }
-                        if(handleNameAlreadyExist(error, snackError)){
+                        if (handleNameAlreadyExist(error, snackError)) {
                             return;
                         }
                         handlePasteError(error);
@@ -162,7 +162,7 @@ const DirectoryTreeContextualMenu: React.FC<DirectoryTreeContextualMenuProps> = 
                         ElementType.PARAMETERS,
                         selectionForCopy.typeItem
                     ).catch((error: any) => {
-                        if(handleNameAlreadyExist(error, snackError)){
+                        if (handleNameAlreadyExist(error, snackError)) {
                             return;
                         }
                         handlePasteError(error);
@@ -175,7 +175,7 @@ const DirectoryTreeContextualMenu: React.FC<DirectoryTreeContextualMenuProps> = 
                         selectionForCopy.typeItem,
                         selectionForCopy.specificType
                     ).catch((error: any) => {
-                        if(handleNameAlreadyExist(error, snackError)){
+                        if (handleNameAlreadyExist(error, snackError)) {
                             return;
                         }
                         handlePasteError(error);

--- a/src/components/menus/directory-tree-contextual-menu.tsx
+++ b/src/components/menus/directory-tree-contextual-menu.tsx
@@ -38,7 +38,7 @@ import ContingencyListCreationDialog from '../dialogs/contingency-list/creation/
 import CreateCaseDialog from '../dialogs/create-case-dialog/create-case-dialog';
 import { useParameterState } from '../dialogs/use-parameters-dialog';
 import { PARAM_LANGUAGE } from '../../utils/config-params';
-import { handleMaxElementsExceededError } from '../utils/rest-errors';
+import { handleMaxElementsExceededError, handleNameAlreadyExist } from '../utils/rest-errors';
 import { PopoverPosition, PopoverReference } from '@mui/material';
 import { AppState } from 'redux/reducer';
 
@@ -145,6 +145,9 @@ const DirectoryTreeContextualMenu: React.FC<DirectoryTreeContextualMenuProps> = 
                         if (handleMaxElementsExceededError(error, snackError)) {
                             return;
                         }
+                        if(handleNameAlreadyExist(error, snackError)){
+                            return;
+                        }
                         handlePasteError(error);
                     });
                     break;
@@ -159,6 +162,9 @@ const DirectoryTreeContextualMenu: React.FC<DirectoryTreeContextualMenuProps> = 
                         ElementType.PARAMETERS,
                         selectionForCopy.typeItem
                     ).catch((error: any) => {
+                        if(handleNameAlreadyExist(error, snackError)){
+                            return;
+                        }
                         handlePasteError(error);
                     });
                     break;
@@ -169,6 +175,9 @@ const DirectoryTreeContextualMenu: React.FC<DirectoryTreeContextualMenuProps> = 
                         selectionForCopy.typeItem,
                         selectionForCopy.specificType
                     ).catch((error: any) => {
+                        if(handleNameAlreadyExist(error, snackError)){
+                            return;
+                        }
                         handlePasteError(error);
                     });
                     break;

--- a/src/components/utils/rest-errors.ts
+++ b/src/components/utils/rest-errors.ts
@@ -21,3 +21,13 @@ export const handleMaxElementsExceededError = (error: CustomError, snackError: F
     }
     return false;
 };
+
+export const handleNameAlreadyExist = (error: CustomError, snackError: Function): boolean => {
+    if (error.status === 409) {
+        snackError({
+            messageTxt: error.message,
+        });
+        return true;
+    }
+    return false;
+};


### PR DESCRIPTION
This PR adds error handling for element duplication conflicts and displays an error message when such conflicts occur.

https://github.com/gridsuite/directory-server/pull/158
https://github.com/gridsuite/gridexplore-app/pull/513