### PR TITLE
fix remove useless test

### DIFF
--- a/src/components/tree-views-container.jsx
+++ b/src/components/tree-views-container.jsx
@@ -318,7 +318,7 @@ const TreeViewsContainer = () => {
     const mergeCurrentAndUploading = useCallback(
         (current) => {
             let uploadingElementsInSelectedDirectory = Object.values(uploadingElementsRef.current).filter(
-                (e) => e.directory === selectedDirectoryRef.current.elementUuid && current[e.elementName] === undefined // WTF ?
+                (e) => e.directory === selectedDirectoryRef.current.elementUuid
             );
             if (uploadingElementsInSelectedDirectory?.length > 0) {
                 // Reduce uploadingElementsInSelectedDirectory to get


### PR DESCRIPTION
fix(): remove strange test over an array access by element.name. Could have create strange case if element name is an integer no ?