### PR TITLE
Optim, add user identities cache 

### DIFF
--- a/src/hooks/useDirectoryContent.ts
+++ b/src/hooks/useDirectoryContent.ts
@@ -62,7 +62,7 @@ export const useDirectoryContent = () => {
         const childrenToFetchUsersIdentitiesInfos = Object.values(currentChildren)
             .filter(
                 (e) =>
-                    knownUsersIdentitiesRef.current?.[e.owner] === undefined &&
+                    knownUsersIdentitiesRef.current?.[e.owner] === undefined ||
                     knownUsersIdentitiesRef.current?.[e.lastModifiedBy] === undefined
             )
             .map((e) => e.elementUuid);

--- a/src/utils/rest-api.ts
+++ b/src/utils/rest-api.ts
@@ -185,7 +185,11 @@ export function fetchVersion() {
 }
 
 export function fetchUsersIdentities(elementUuids: string[]) {
-    console.info('fetching users identities for elements : %s', elementUuids);
+    if (elementUuids.length === 0) {
+        return Promise.resolve();
+    }
+    console.info('fetching users identities for %s elements.', elementUuids.length);
+    console.debug('fetching users identities for elements: %s', elementUuids);
     const idsParams = getRequestParamFromList('ids', elementUuids).toString();
     const fetchParams = `${PREFIX_EXPLORE_SERVER_QUERIES}/v1/explore/elements/users-identities?${idsParams}`;
     return backendFetchJson(fetchParams, {

--- a/src/utils/rest-api.ts
+++ b/src/utils/rest-api.ts
@@ -189,7 +189,6 @@ export function fetchUsersIdentities(elementUuids: string[]) {
         return Promise.resolve();
     }
     console.info('fetching users identities for %s elements.', elementUuids.length);
-    console.debug('fetching users identities for elements: %s', elementUuids);
     const idsParams = getRequestParamFromList('ids', elementUuids).toString();
     const fetchParams = `${PREFIX_EXPLORE_SERVER_QUERIES}/v1/explore/elements/users-identities?${idsParams}`;
     return backendFetchJson(fetchParams, {


### PR DESCRIPTION
Add a local cache and avoid multiple fetches if identity is already known.
If some user identities fetch return errors for some sub, it will retry during navigation if an element is owned or lastly modified by this user in the directory.