### PR TITLE
Fix vite HMR whith multi exports in jsx or tsx files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
         "jest.config.ts",
         "jest.setup.ts"
     ],
+    "plugins": ["react-refresh"],
     "rules": {
         "prettier/prettier": "warn",
         "curly": "error",
@@ -25,6 +26,10 @@
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
         "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-        "import/prefer-default-export": "off"
+        "import/prefer-default-export": "off",
+        "react-refresh/only-export-components": [
+            "error",
+            { "allowConstantExport": true }
+        ]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
                 "eslint-plugin-prettier": "^4.2.1",
                 "eslint-plugin-react": "^7.34.1",
                 "eslint-plugin-react-hooks": "^4.6.0",
+                "eslint-plugin-react-refresh": "^0.4.18",
                 "identity-obj-proxy": "^3.0.0",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.7.0",
@@ -8299,6 +8300,15 @@
             },
             "peerDependencies": {
                 "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            }
+        },
+        "node_modules/eslint-plugin-react-refresh": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.18.tgz",
+            "integrity": "sha512-IRGEoFn3OKalm3hjfolEWGqoF/jPqeEYFp+C8B0WMzwGwBMvlRDQd06kghDhF0C61uJ6WfSDhEZE/sAQjduKgw==",
+            "dev": true,
+            "peerDependencies": {
+                "eslint": ">=8.40"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-refresh": "^0.4.18",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
chore(): install eslint-plugin-react-refresh to disable multi exports in jsx or tsx files.