### PR TITLE
Add directory owner in the directory properties dialog

### DIFF
--- a/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
+++ b/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
@@ -193,6 +193,10 @@ function DirectoryPropertiesDialog({ open, onClose, directory }: Readonly<Direct
                     ) : (
                         <Box sx={{ mt: 2 }}>
                             <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>
+                                <FormattedMessage id="directoryOwner" values={{ owner: directory?.owner }} />
+                            </Typography>
+
+                            <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>
                                 <FormattedMessage id="directoryPermissions" />
                             </Typography>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -189,6 +189,7 @@
     "deleteConflictError": "You cannot delete this folder since it contains at least one subfolder for which you do not have write permission",
     "properties": "Properties",
     "directoryProperties": "Directory Properties: {name}",
+    "directoryOwner": "Owner: {owner}",
     "directoryPermissions": "Manage access",
     "directoryPermissionsViewOnly": "You can view but not modify the permissions of this directory",
     "directoryPermissionsFetchError": "Error while fetching directory permissions",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -188,6 +188,7 @@
     "deleteConflictError": "Vous ne pouvez pas supprimer ce dossier puisqu'il contient au moins un sous-dossier pour lequel vous n'avez pas les droits d'écriture.",
     "properties": "Propriétés",
     "directoryProperties": "Propriétés du dossier: {name}",
+    "directoryOwner": "Propriétaire: {owner}",
     "directoryPermissions": "Gestion d'accès",
     "directoryPermissionsViewOnly": "Vous pouvez voir mais pas modifier les permissions pour ce dossier",
     "directoryPermissionsFetchError": "Erreur lors de la récupération des permissions du dossier",


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Before : In the directory properties dialog (in GridExpore), the directory owner is not shown
After : In the directory properties dialog (in GridExpore), the directory owner is now shown



