### PR TITLE
Display directory owner identity in the directory properties dialog

### DIFF
--- a/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
+++ b/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
@@ -25,6 +25,7 @@ import {
     hasManagePermission,
     PermissionDTO,
     PermissionType,
+    fetchUsersIdentities,
 } from '../../../utils/rest-api';
 import {
     Group,
@@ -50,6 +51,7 @@ function DirectoryPropertiesDialog({ open, onClose, directory }: Readonly<Direct
     const [loading, setLoading] = useState(true);
     const [groups, setGroups] = useState<Group[]>([]);
     const [canManage, setCanManage] = useState(false);
+    const [directoryOwnerIdentity, setDirectoryOwnerIdentity] = useState<string | undefined>(directory?.owner);
 
     const methods = useForm<PermissionForm>({
         defaultValues: emptyForm,
@@ -119,11 +121,32 @@ function DirectoryPropertiesDialog({ open, onClose, directory }: Readonly<Direct
         }
     }, [directory?.elementUuid, snackError, reset]);
 
+    const fetchDirectoryOwnerIdentity = useCallback(async () => {
+        if (!directory?.owner || !directory?.elementUuid) return;
+
+        fetchUsersIdentities([directory.elementUuid])
+            .then((res) => {
+                if (res?.data?.[directory.owner]?.firstName && res?.data?.[directory.owner]?.lastName) {
+                    setDirectoryOwnerIdentity(
+                        `${res?.data?.[directory.owner]?.firstName} ${res?.data?.[directory.owner]?.lastName}`
+                    );
+                }
+            })
+            .catch((error) => {
+                snackError({
+                    messageTxt: error.message,
+                    headerId: 'directoryOwnerIdentityFetchError',
+                });
+                setDirectoryOwnerIdentity(undefined);
+            });
+    }, [directory?.owner, directory?.elementUuid, snackError]);
+
     useEffect(() => {
         if (open && directory) {
             fetchData();
+            fetchDirectoryOwnerIdentity();
         }
-    }, [open, directory, fetchData]);
+    }, [open, directory, fetchData, fetchDirectoryOwnerIdentity]);
 
     const handleClose = useCallback(() => {
         reset(emptyForm);
@@ -193,7 +216,7 @@ function DirectoryPropertiesDialog({ open, onClose, directory }: Readonly<Direct
                     ) : (
                         <Box sx={{ mt: 2 }}>
                             <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>
-                                <FormattedMessage id="directoryOwner" values={{ owner: directory?.owner }} />
+                                <FormattedMessage id="directoryOwner" values={{ owner: directoryOwnerIdentity }} />
                             </Typography>
 
                             <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>

--- a/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
+++ b/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
@@ -137,7 +137,6 @@ function DirectoryPropertiesDialog({ open, onClose, directory }: Readonly<Direct
                     messageTxt: error.message,
                     headerId: 'directoryOwnerIdentityFetchError',
                 });
-                setDirectoryOwnerIdentity(undefined);
             });
     }, [directory?.owner, directory?.elementUuid, snackError]);
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -194,6 +194,7 @@
     "directoryPermissionsViewOnly": "You can view but not modify the permissions of this directory",
     "directoryPermissionsFetchError": "Error while fetching directory permissions",
     "directoryPermissionsUpdateError": "Error while updating directory permissions",
+    "directoryOwnerIdentityFetchError": "Error while fetching directory owner",
     "readOnly": "Read only",
     "read&Write": "Read / Write",
     "allUsers": "Anyone",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -193,6 +193,7 @@
     "directoryPermissionsViewOnly": "Vous pouvez voir mais pas modifier les permissions pour ce dossier",
     "directoryPermissionsFetchError": "Erreur lors de la récupération des permissions du dossier",
     "directoryPermissionsUpdateError": "Erreur lors de la mise à jour des permissions du dossier",
+    "directoryOwnerIdentityFetchError": "Erreur lors de la récupération du créateur du dossier",
     "readOnly": "Lecture seule",
     "read&Write": "Lecture / Écriture",
     "allUsers": "Tout le monde",


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

In the directory properties dialog, instead of displaying the directory owner, as it is stored in the directory-server database, we display now the directory owner identity, to be consistent with what is displayed in the tooltip for a directory element.




