### PR TITLE
Small change for directory owner size and font label in properties dialog

### DIFF
--- a/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
+++ b/src/components/dialogs/directory-properties/directory-properties-dialog.tsx
@@ -214,7 +214,7 @@ function DirectoryPropertiesDialog({ open, onClose, directory }: Readonly<Direct
                         </Box>
                     ) : (
                         <Box sx={{ mt: 2 }}>
-                            <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>
+                            <Typography variant="subtitle1" gutterBottom sx={{ mb: 2 }}>
                                 <FormattedMessage id="directoryOwner" values={{ owner: directoryOwnerIdentity }} />
                             </Typography>
 


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Reduce size and remove bold font for directory owner label in properties dialog 



