### PR TITLE
chore(commons-ui): bump v0.139.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.138.0",
+                "@gridsuite/commons-ui": "0.139.0",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^5.18.0",
                 "@mui/lab": "5.0.0-alpha.175",
@@ -3262,9 +3262,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.138.0.tgz",
-            "integrity": "sha512-A/qZEaCz6EFPH9XK6Jo3SdIyEJ528jGM8UhnnrVv+xe8jvz5uASdmL2zEUhApOOI2/MRFM68DnOe3gPVrDbhBQ==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.139.0.tgz",
+            "integrity": "sha512-ZYMuOdLQJmsHw96Xme+kgrOuyGnR9fPaiWxbKe0wriyJ6lzz83r9gF6H5NMOAPYFiPRWtfi7HizXos9wQdHLXA==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.138.0",
+        "@gridsuite/commons-ui": "0.139.0",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^5.18.0",
         "@mui/lab": "5.0.0-alpha.175",

--- a/src/components/dialogs/contingency-list/filter-based/filter-based-contingency-list-visualization-panel.tsx
+++ b/src/components/dialogs/contingency-list/filter-based/filter-based-contingency-list-visualization-panel.tsx
@@ -16,7 +16,7 @@ import {
     DirectoryItemSelector,
     ElementType,
     FieldConstants,
-    getFilterEquipmentTypeLabel,
+    getEquipmentTypeShortLabel,
     SeparatorCellRenderer,
     TreeViewFinderNodeProps,
     useSnackMessage,
@@ -72,7 +72,7 @@ export function FilterBasedContingencyListVisualizationPanel(
 
     const getTranslatedEquipmentType = useCallback(
         (type: string | undefined) => {
-            const equipmentType = getFilterEquipmentTypeLabel(type);
+            const equipmentType = getEquipmentTypeShortLabel(type);
             return equipmentType ? intl.formatMessage({ id: equipmentType }) : '';
         },
         [intl]


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Bump new version of commons-ui v0.139.0.

Use the new `getEquipmentTypeShortLabel` instead of `getFilterEquipmentTypeLabel`

