### PR TITLE
Avoid element edition when no write permission

### DIFF
--- a/src/components/directory-content-dialog.tsx
+++ b/src/components/directory-content-dialog.tsx
@@ -44,7 +44,7 @@ import type { AppState } from '../redux/types';
 import { useParameterState } from './dialogs/use-parameters-dialog';
 import type { useDirectoryContent } from '../hooks/useDirectoryContent';
 import FilterBasedContingencyListDialog from './dialogs/contingency-list/filter-based/contingency-list-filter-based-dialog';
-import { DESCRIPTION_FIELD } from './utils/directory-content-utils';
+import { DirectoryField } from './utils/directory-content-utils';
 
 export type DirectoryContentDialogApi = {
     handleClick: (event: CellClickedEvent) => void;
@@ -218,7 +218,7 @@ function DirectoryContentDialog(
                     /** no element can be opened */
                     return;
                 }
-                if (event.colDef.field === DESCRIPTION_FIELD) {
+                if (event.colDef.field === DirectoryField.DESCRIPTION) {
                     /** open description dialog */
                     setActiveElement(event.data);
                     setOpenDescModificationDialog(true);
@@ -277,7 +277,7 @@ function DirectoryContentDialog(
         ]
     );
 
-    if (activeElement && activeDirectory) {
+    if (activeElement) {
         if (openDescModificationDialog) {
             return (
                 <DescriptionModificationDialog
@@ -363,7 +363,8 @@ function DirectoryContentDialog(
                 />
             );
         }
-        if (currentParametersId) {
+
+        if (currentParametersId && activeDirectory) {
             if (currentParametersType === ElementType.LOADFLOW_PARAMETERS) {
                 return (
                     <LoadFlowParametersEditionDialog

--- a/src/components/directory-content-table.tsx
+++ b/src/components/directory-content-table.tsx
@@ -68,18 +68,18 @@ export function DirectoryContentTable({
     const getCustomRowStyle = useCallback(
         (cellData: RowClassParams<ElementAttributes>) => {
             const style: RowStyle = { fontSize: '1rem' };
-            const unEditableElements = [
-                ElementType.CASE,
-                ElementType.DIAGRAM_CONFIG,
-                ElementType.SPREADSHEET_CONFIG,
-                ElementType.SPREADSHEET_CONFIG_COLLECTION,
-            ];
-            if (cellData.data) {
-                if (cellData.data.type === ElementType.STUDY && !selectedDirectoryWritable) {
-                    style.cursor = 'not-allowed';
-                } else if (!unEditableElements.includes(cellData.data.type)) {
-                    style.cursor = 'pointer';
-                }
+            const editableElement = () => {
+                const READ_ONLY_ELEMENTS = [
+                    ElementType.CASE,
+                    ElementType.DIAGRAM_CONFIG,
+                    ElementType.SPREADSHEET_CONFIG,
+                    ElementType.SPREADSHEET_CONFIG_COLLECTION,
+                ];
+                return cellData.data && !READ_ONLY_ELEMENTS.includes(cellData.data.type);
+            };
+
+            if (selectedDirectoryWritable && editableElement()) {
+                style.cursor = 'pointer';
             }
             return {
                 ...style,

--- a/src/components/directory-content.tsx
+++ b/src/components/directory-content.tsx
@@ -331,7 +331,7 @@ export default function DirectoryContent() {
                             handleCellContextualMenu={onCellContextMenu}
                             handleRowSelected={updateCheckedRows}
                             handleCellClick={handleCellClick}
-                            colDef={getColumnsDefinition(childrenMetadata, intl)}
+                            colDef={getColumnsDefinition(childrenMetadata, intl, directoryWritable)}
                             getRowStyle={getRowStyle}
                             onGridReady={onGridReady}
                             selectedDirectoryWritable={directoryWritable}

--- a/src/components/directory-content.tsx
+++ b/src/components/directory-content.tsx
@@ -270,6 +270,49 @@ export default function DirectoryContent() {
         updateCheckedRows();
     }, [childrenMetadata, updateCheckedRows]); // this will change after switching selectedDirectory
 
+    const renderDirectoryContent = () => {
+        // Loading state - waiting for metadata
+        if (isMissingDataAfterDirChange) {
+            return (
+                <Box sx={styles.circularProgressContainer}>
+                    <CircularProgress
+                        size={circularProgressSize}
+                        color="inherit"
+                        sx={styles.centeredCircularProgress}
+                    />
+                </Box>
+            );
+        }
+
+        // No rows or directory selected
+        if (!rows || !selectedDirectory) {
+            if (treeData.rootDirectories.length === 0 && treeData.initialized) {
+                return <NoContentDirectory handleOpenDialog={handleOpenDialog} />;
+            }
+            return undefined;
+        }
+
+        // Empty directory then render a specific content
+        if (rows.length === 0) {
+            return <EmptyDirectory onCreateElementButtonClick={handleEmptyDirectoryClick} />;
+        }
+
+        // Finally, if we have some elements, then render the table
+        return (
+            <DirectoryContentTable
+                gridRef={gridRef}
+                rows={rows}
+                handleCellContextualMenu={onCellContextMenu}
+                handleRowSelected={updateCheckedRows}
+                handleCellClick={handleCellClick}
+                colDef={getColumnsDefinition(childrenMetadata, intl, directoryWritable)}
+                getRowStyle={getRowStyle}
+                onGridReady={onGridReady}
+                selectedDirectoryWritable={directoryWritable}
+            />
+        );
+    };
+
     return (
         <>
             {
@@ -303,41 +346,7 @@ export default function DirectoryContent() {
                 onContextMenu={onContextMenu}
                 data-testid="DirectoryContent"
             >
-                {/* eslint-disable no-nested-ternary -- TODO split into sub components */}
-                {
-                    // Here we wait for Metadata for the folder content
-                    isMissingDataAfterDirChange ? (
-                        // render loading content
-                        <Box sx={styles.circularProgressContainer}>
-                            <CircularProgress
-                                size={circularProgressSize}
-                                color="inherit"
-                                sx={styles.centeredCircularProgress}
-                            />
-                        </Box>
-                    ) : // If no selection or currentChildren = null (first time) render nothing
-                    !rows || !selectedDirectory ? (
-                        treeData.rootDirectories.length === 0 && treeData.initialized ? (
-                            <NoContentDirectory handleOpenDialog={handleOpenDialog} />
-                        ) : undefined
-                    ) : // If empty dir then render an appropriate content
-                    rows.length === 0 ? (
-                        <EmptyDirectory onCreateElementButtonClick={handleEmptyDirectoryClick} />
-                    ) : (
-                        // Finally if we have elements then render the table
-                        <DirectoryContentTable
-                            gridRef={gridRef}
-                            rows={rows}
-                            handleCellContextualMenu={onCellContextMenu}
-                            handleRowSelected={updateCheckedRows}
-                            handleCellClick={handleCellClick}
-                            colDef={getColumnsDefinition(childrenMetadata, intl, directoryWritable)}
-                            getRowStyle={getRowStyle}
-                            onGridReady={onGridReady}
-                            selectedDirectoryWritable={directoryWritable}
-                        />
-                    )
-                }
+                {renderDirectoryContent()}
             </Box>
             <Box onMouseDown={handleBoxDownClick}>
                 {activeElement && (

--- a/src/components/menus/directory-tree-contextual-menu.tsx
+++ b/src/components/menus/directory-tree-contextual-menu.tsx
@@ -270,11 +270,10 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                     messageDescriptorId: 'ImportNewCase',
                     callback: () => handleOpenDialog(DialogsId.ADD_NEW_CASE),
                     icon: <AddIcon fontSize="small" data-testid="ImportNewCaseIcon" />,
-                }
+                },
+                { isDivider: true }
             );
         }
-
-        menuItems.push({ isDivider: true });
 
         if (!restrictMenuItems) {
             if (directory && directoryWritable) {
@@ -309,25 +308,23 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                     icon: <ContentPasteIcon fontSize="small" data-testid="PasteIcon" />,
                     disabled: !itemSelectionForCopy.sourceItemUuid,
                 },
-                { isDivider: true }
+                { isDivider: true },
+                {
+                    messageDescriptorId: 'createFolder',
+                    callback: () => handleOpenDialog(DialogsId.ADD_DIRECTORY),
+                    icon: <CreateNewFolderIcon fontSize="small" data-testid="CreateFolderIcon" />,
+                }
             );
         }
 
-        if (directory && directoryWritable) {
-            menuItems.push({
-                messageDescriptorId: 'createFolder',
-                callback: () => handleOpenDialog(DialogsId.ADD_DIRECTORY),
-                icon: <CreateNewFolderIcon fontSize="small" data-testid="CreateFolderIcon" />,
-            });
-        }
-
-        menuItems.push({
-            messageDescriptorId: 'createRootFolder',
-            callback: () => handleOpenDialog(DialogsId.ADD_ROOT_DIRECTORY),
-            icon: <FolderSpecialIcon fontSize="small" data-testid="CreateRootFolderIcon" />,
-        });
-
-        menuItems.push({ isDivider: true });
+        menuItems.push(
+            {
+                messageDescriptorId: 'createRootFolder',
+                callback: () => handleOpenDialog(DialogsId.ADD_ROOT_DIRECTORY),
+                icon: <FolderSpecialIcon fontSize="small" data-testid="CreateRootFolderIcon" />,
+            },
+            { isDivider: true }
+        );
 
         if (directory) {
             menuItems.push({

--- a/src/components/utils/directory-content-utils.ts
+++ b/src/components/utils/directory-content-utils.ts
@@ -18,6 +18,8 @@ import { UserCellRenderer } from './renderers/user-cell-renderer';
 import { DateCellRenderer } from './renderers/date-cell-renderer';
 import { getElementTypeTranslation } from './translation-utils';
 
+export const DESCRIPTION_FILED = 'description';
+
 export const formatMetadata = (
     data: ElementAttributes,
     childrenMetadata: Record<UUID, ElementAttributes>
@@ -56,7 +58,11 @@ export const defaultColumnDefinition: ColDef<unknown> = {
     },
 };
 
-export const getColumnsDefinition = (childrenMetadata: Record<UUID, ElementAttributes>, intl: IntlShape): ColDef[] => [
+export const getColumnsDefinition = (
+    childrenMetadata: Record<UUID, ElementAttributes>,
+    intl: IntlShape,
+    directoryWritable: boolean
+): ColDef[] => [
     {
         headerName: intl.formatMessage({
             id: 'elementName',
@@ -74,8 +80,11 @@ export const getColumnsDefinition = (childrenMetadata: Record<UUID, ElementAttri
         headerName: intl.formatMessage({
             id: 'description',
         }),
-        field: 'description',
+        field: DESCRIPTION_FILED,
         cellRenderer: DescriptionCellRenderer,
+        cellRendererParams: {
+            directoryWritable,
+        },
         sortable: false,
         minWidth: 110,
         flex: 1,

--- a/src/components/utils/directory-content-utils.ts
+++ b/src/components/utils/directory-content-utils.ts
@@ -18,7 +18,7 @@ import { UserCellRenderer } from './renderers/user-cell-renderer';
 import { DateCellRenderer } from './renderers/date-cell-renderer';
 import { getElementTypeTranslation } from './translation-utils';
 
-export const DESCRIPTION_FILED = 'description';
+export const DESCRIPTION_FIELD = 'description';
 
 export const formatMetadata = (
     data: ElementAttributes,
@@ -81,7 +81,7 @@ export const getColumnsDefinition = (
         headerName: intl.formatMessage({
             id: 'description',
         }),
-        field: DESCRIPTION_FILED,
+        field: DESCRIPTION_FIELD,
         cellRenderer: DescriptionCellRenderer,
         cellRendererParams: {
             directoryWritable,

--- a/src/components/utils/directory-content-utils.ts
+++ b/src/components/utils/directory-content-utils.ts
@@ -18,7 +18,15 @@ import { UserCellRenderer } from './renderers/user-cell-renderer';
 import { DateCellRenderer } from './renderers/date-cell-renderer';
 import { getElementTypeTranslation } from './translation-utils';
 
-export const DESCRIPTION_FIELD = 'description';
+export enum DirectoryField {
+    NAME = 'elementName',
+    DESCRIPTION = 'description',
+    TYPE = 'type',
+    OWNER = 'ownerLabel',
+    CREATION_DATE = 'creationDate',
+    LAST_UPDATE_LABEL = 'lastModifiedByLabel',
+    LAST_UPDATE_DATE = 'lastModificationDate',
+}
 
 export const formatMetadata = (
     data: ElementAttributes,
@@ -65,9 +73,9 @@ export const getColumnsDefinition = (
 ): ColDef[] => [
     {
         headerName: intl.formatMessage({
-            id: 'elementName',
+            id: DirectoryField.NAME,
         }),
-        field: 'elementName',
+        field: DirectoryField.NAME,
         pinned: true,
         cellRenderer: NameCellRenderer,
         cellRendererParams: {
@@ -79,9 +87,9 @@ export const getColumnsDefinition = (
     },
     {
         headerName: intl.formatMessage({
-            id: 'description',
+            id: DirectoryField.DESCRIPTION,
         }),
-        field: DESCRIPTION_FIELD,
+        field: DirectoryField.DESCRIPTION,
         cellRenderer: DescriptionCellRenderer,
         cellRendererParams: {
             directoryWritable,
@@ -92,9 +100,9 @@ export const getColumnsDefinition = (
     },
     {
         headerName: intl.formatMessage({
-            id: 'type',
+            id: DirectoryField.TYPE,
         }),
-        field: 'type',
+        field: DirectoryField.TYPE,
         sortable: true,
         cellRenderer: TypeCellRenderer,
         cellRendererParams: {
@@ -131,7 +139,7 @@ export const getColumnsDefinition = (
         headerName: intl.formatMessage({
             id: 'creator',
         }),
-        field: 'ownerLabel',
+        field: DirectoryField.OWNER,
         cellRenderer: UserCellRenderer,
         minWidth: 110,
         flex: 1,
@@ -140,7 +148,7 @@ export const getColumnsDefinition = (
         headerName: intl.formatMessage({
             id: 'created',
         }),
-        field: 'creationDate',
+        field: DirectoryField.CREATION_DATE,
         cellRenderer: DateCellRenderer,
         minWidth: 130,
         flex: 2,
@@ -149,7 +157,7 @@ export const getColumnsDefinition = (
         headerName: intl.formatMessage({
             id: 'modifiedBy',
         }),
-        field: 'lastModifiedByLabel',
+        field: DirectoryField.LAST_UPDATE_LABEL,
         cellRenderer: UserCellRenderer,
         minWidth: 110,
         flex: 1,
@@ -158,7 +166,7 @@ export const getColumnsDefinition = (
         headerName: intl.formatMessage({
             id: 'modified',
         }),
-        field: 'lastModificationDate',
+        field: DirectoryField.LAST_UPDATE_DATE,
         cellRenderer: DateCellRenderer,
         minWidth: 130,
         flex: 2,

--- a/src/components/utils/directory-content-utils.ts
+++ b/src/components/utils/directory-content-utils.ts
@@ -72,8 +72,9 @@ export const getColumnsDefinition = (
         cellRenderer: NameCellRenderer,
         cellRendererParams: {
             childrenMetadata,
+            directoryWritable,
         },
-        cellStyle: { display: 'flex' },
+        flex: 2,
         minWidth: 400,
     },
     {

--- a/src/components/utils/renderers/date-cell-renderer.tsx
+++ b/src/components/utils/renderers/date-cell-renderer.tsx
@@ -32,7 +32,7 @@ export function DateCellRenderer({ value }: Readonly<DateCellRendererProps>) {
 
         return (
             <Box>
-                <Tooltip title={fullDate} placement="right">
+                <Tooltip title={fullDate}>
                     <span>{cellText}</span>
                 </Tooltip>
             </Box>

--- a/src/components/utils/renderers/description-cell-renderer.tsx
+++ b/src/components/utils/renderers/description-cell-renderer.tsx
@@ -31,7 +31,7 @@ export function DescriptionCellRenderer({ data, directoryWritable }: Readonly<De
     const tooltip = descriptionLines?.join('\n');
 
     const icon = description ? (
-        <Tooltip title={<Box sx={styles.descriptionTooltip}>{tooltip}</Box>} placement="right">
+        <Tooltip title={<Box sx={styles.descriptionTooltip}>{tooltip}</Box>}>
             <StickyNote2OutlinedIcon />
         </Tooltip>
     ) : (

--- a/src/components/utils/renderers/description-cell-renderer.tsx
+++ b/src/components/utils/renderers/description-cell-renderer.tsx
@@ -20,9 +20,9 @@ const styles = {
     },
 } as const satisfies MuiStyles;
 
-export type DescriptionCellRendererProps = { data: ElementAttributes };
+export type DescriptionCellRendererProps = { data: ElementAttributes; directoryWritable: boolean };
 
-export function DescriptionCellRenderer({ data }: Readonly<DescriptionCellRendererProps>) {
+export function DescriptionCellRenderer({ data, directoryWritable }: Readonly<DescriptionCellRendererProps>) {
     const { description } = data;
     const descriptionLines = description?.split('\n');
     if (descriptionLines?.length > 3) {
@@ -42,7 +42,7 @@ export function DescriptionCellRenderer({ data }: Readonly<DescriptionCellRender
             sx={{
                 display: 'inline-flex',
                 verticalAlign: 'middle',
-                cursor: 'pointer',
+                cursor: directoryWritable ? 'pointer' : undefined,
             }}
         >
             {icon}

--- a/src/components/utils/renderers/name-cell-renderer.tsx
+++ b/src/components/utils/renderers/name-cell-renderer.tsx
@@ -6,11 +6,13 @@
  */
 import type { UUID } from 'node:crypto';
 import { IntlShape, useIntl } from 'react-intl';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Tooltip } from '@mui/material';
+import { Lock as LockIcon } from '@mui/icons-material';
 import {
     type ElementAttributes,
     ElementType,
     getFileIcon,
+    mergeSx,
     type MuiStyles,
     OverflowableText,
 } from '@gridsuite/commons-ui';
@@ -48,25 +50,21 @@ const styles = {
         width: '18px',
         height: '18px',
     }),
+    right: (theme) => ({
+        marginLeft: 'auto',
+    }),
     tooltip: {
         maxWidth: '1000px',
-    },
-    overflow: {
-        display: 'inline-block',
-        whiteSpace: 'pre',
-        textOverflow: 'ellipsis',
-        overflow: 'hidden',
-        lineHeight: 'initial',
-        verticalAlign: 'middle',
     },
 } as const satisfies MuiStyles;
 
 export type NameCellRendererProps = {
     data: ElementAttributes;
     childrenMetadata: Record<UUID, ElementAttributes>;
+    directoryWritable: boolean;
 };
 
-export function NameCellRenderer({ data, childrenMetadata }: Readonly<NameCellRendererProps>) {
+export function NameCellRenderer({ data, childrenMetadata, directoryWritable }: Readonly<NameCellRendererProps>) {
     const intl = useIntl();
     return (
         <Box sx={styles.tableCell}>
@@ -79,9 +77,13 @@ export function NameCellRenderer({ data, childrenMetadata }: Readonly<NameCellRe
             <OverflowableText
                 text={getDisplayedElementName(data, childrenMetadata, intl)}
                 tooltipSx={styles.tooltip}
-                style={styles.overflow}
                 data-testid="ElementName"
             />
+            {!directoryWritable && (
+                <Tooltip title="Element protégé">
+                    <LockIcon sx={mergeSx(styles.icon, styles.right)} />
+                </Tooltip>
+            )}
         </Box>
     );
 }

--- a/src/components/utils/renderers/name-cell-renderer.tsx
+++ b/src/components/utils/renderers/name-cell-renderer.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 import type { UUID } from 'node:crypto';
-import { IntlShape, useIntl } from 'react-intl';
+import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
 import { Box, CircularProgress, Tooltip } from '@mui/material';
 import { Lock as LockIcon } from '@mui/icons-material';
 import {
@@ -50,9 +50,9 @@ const styles = {
         width: '18px',
         height: '18px',
     }),
-    right: (theme) => ({
+    right: {
         marginLeft: 'auto',
-    }),
+    },
     tooltip: {
         maxWidth: '1000px',
     },
@@ -80,7 +80,7 @@ export function NameCellRenderer({ data, childrenMetadata, directoryWritable }: 
                 data-testid="ElementName"
             />
             {!directoryWritable && (
-                <Tooltip title="Element protégé">
+                <Tooltip title={<FormattedMessage id="protectedElement" />}>
                     <LockIcon sx={mergeSx(styles.icon, styles.right)} />
                 </Tooltip>
             )}

--- a/src/components/utils/renderers/name-cell-renderer.tsx
+++ b/src/components/utils/renderers/name-cell-renderer.tsx
@@ -75,12 +75,13 @@ export type NameCellRendererProps = {
 
 export function NameCellRenderer({ data, childrenMetadata, directoryWritable }: Readonly<NameCellRendererProps>) {
     const intl = useIntl();
-    const waiting = waitingForAsyncCreation(childrenMetadata[data.elementUuid], data.type);
+    const metadata = childrenMetadata[data.elementUuid];
+    const waiting = waitingForAsyncCreation(metadata, data.type);
     return (
         <Box sx={styles.tableCell}>
             {/*  Icon */}
             {waiting && <CircularProgress size={18} sx={styles.icon} />}
-            {childrenMetadata[data.elementUuid] && getFileIcon(data.type, styles.icon)}
+            {metadata && getFileIcon(data.type, styles.icon)}
             {/* Name */}
             <OverflowableText
                 text={getDisplayedElementName(data, childrenMetadata, intl)}

--- a/src/components/utils/renderers/user-cell-renderer.tsx
+++ b/src/components/utils/renderers/user-cell-renderer.tsx
@@ -49,7 +49,7 @@ export type UserCellRendererProps = { value: string };
 export function UserCellRenderer({ value }: Readonly<UserCellRendererProps>) {
     return (
         <Box sx={{ display: 'inline-flex', verticalAlign: 'middle' }}>
-            <Tooltip title={value} placement="right">
+            <Tooltip title={value}>
                 <Avatar sx={mergeSx(styles.avatar, value ? { backgroundColor: stringToColor(value) } : null)}>
                     {getAbbreviationFromUserName(value)}
                 </Avatar>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -198,6 +198,7 @@
     "allUsers": "Anyone",
     "restricted": "Restricted",
     "selectGroups": "Select one or more groups",
+    "protectedElement": "Protected element",
     "visualization": "Visualization",
     "missingEquipmentsFromStudy": "Equipments missing from study",
     "equipmentTypesByFilters": "Contingencies per equipment types in voltage levels & substations",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -197,6 +197,7 @@
     "allUsers": "Tout le monde",
     "restricted": "Restreint",
     "selectGroups": "Sélectionner un ou plusieurs groupes",
+    "protectedElement": "Element protégé",
     "visualization": "Visualisation",
     "missingEquipmentsFromStudy": "Ouvrages absents de l'étude",
     "equipmentTypesByFilters": "Aléas par types d'ouvrage dans les postes et sites",


### PR DESCRIPTION
## PR Summary
Currently, the study element cannot be opened when the user has no write permission on it. This behaviour is generalized to all element types.
The element description dialog cannot be opened anymore as well.
A lock icon and a tooltip are added in the directory elements table to indicate why the opening is disabled.

Also done some refactoring for code readability and maintainability (upon sonar recommandations).

Also fixed:

- use same tooltip placement ('below') for all columns
- fix overflowable style for 'name' column
- fix tooltip update when we resize columns 'name' and 'type'
- fix an extra menu divider 


