### PR TITLE
fix(error-handling): improve type-checking because error in catches are unknown

### DIFF
--- a/src/components/menus/directory-tree-contextual-menu.tsx
+++ b/src/components/menus/directory-tree-contextual-menu.tsx
@@ -22,12 +22,11 @@ import {
     ElementAttributes,
     ElementType,
     FilterCreationDialog,
-    TreeViewFinderNodeProps,
-    useSnackMessage,
+    PARAM_DEVELOPER_MODE,
     PARAM_LANGUAGE,
     PermissionType,
-    CustomError,
-    PARAM_DEVELOPER_MODE,
+    TreeViewFinderNodeProps,
+    useSnackMessage,
 } from '@gridsuite/commons-ui';
 import type { UUID } from 'node:crypto';
 import CreateStudyForm from '../dialogs/create-study-dialog/create-study-dialog';
@@ -140,7 +139,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                 case ElementType.MODIFICATION:
                 case ElementType.DIAGRAM_CONFIG:
                     duplicateElement(selectionForPaste.sourceItemUuid, directoryUuid, selectionForPaste.typeItem).catch(
-                        (error: CustomError) => {
+                        (error) => {
                             if (handleMaxElementsExceededError(error, snackError)) {
                                 return;
                             }
@@ -159,7 +158,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                         directoryUuid,
                         selectionForPaste.typeItem,
                         selectionForPaste.typeItem
-                    ).catch((error: CustomError) => handlePasteError(error, intl, snackError));
+                    ).catch((error) => handlePasteError(error, intl, snackError));
                     break;
                 case ElementType.CONTINGENCY_LIST:
                     duplicateElement(
@@ -167,16 +166,16 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                         directoryUuid,
                         selectionForPaste.typeItem,
                         selectionForPaste.specificTypeItem
-                    ).catch((error: CustomError) => handlePasteError(error, intl, snackError));
+                    ).catch((error) => handlePasteError(error, intl, snackError));
                     break;
                 case ElementType.SPREADSHEET_CONFIG:
-                    duplicateSpreadsheetConfig(selectionForPaste.sourceItemUuid, directoryUuid).catch(
-                        (error: CustomError) => handlePasteError(error, intl, snackError)
+                    duplicateSpreadsheetConfig(selectionForPaste.sourceItemUuid, directoryUuid).catch((error) =>
+                        handlePasteError(error, intl, snackError)
                     );
                     break;
                 case ElementType.SPREADSHEET_CONFIG_COLLECTION:
                     duplicateSpreadsheetConfigCollection(selectionForPaste.sourceItemUuid, directoryUuid).catch(
-                        (error: CustomError) => handlePasteError(error, intl, snackError)
+                        (error) => handlePasteError(error, intl, snackError)
                     );
                     break;
                 default:
@@ -197,7 +196,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
             setDeleteError('');
             deleteElement(elementsUuid)
                 .then(handleCloseDialog)
-                .catch((error: CustomError) => {
+                .catch((error) => {
                     handleDeleteError(setDeleteError, error, intl, snackError);
                 });
         },

--- a/src/components/menus/directory-tree-contextual-menu.tsx
+++ b/src/components/menus/directory-tree-contextual-menu.tsx
@@ -139,7 +139,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                 case ElementType.MODIFICATION:
                 case ElementType.DIAGRAM_CONFIG:
                     duplicateElement(selectionForPaste.sourceItemUuid, directoryUuid, selectionForPaste.typeItem).catch(
-                        (error) => {
+                        (error: unknown) => {
                             if (handleMaxElementsExceededError(error, snackError)) {
                                 return;
                             }
@@ -158,7 +158,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                         directoryUuid,
                         selectionForPaste.typeItem,
                         selectionForPaste.typeItem
-                    ).catch((error) => handlePasteError(error, intl, snackError));
+                    ).catch((error: unknown) => handlePasteError(error, intl, snackError));
                     break;
                 case ElementType.CONTINGENCY_LIST:
                     duplicateElement(
@@ -166,16 +166,16 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
                         directoryUuid,
                         selectionForPaste.typeItem,
                         selectionForPaste.specificTypeItem
-                    ).catch((error) => handlePasteError(error, intl, snackError));
+                    ).catch((error: unknown) => handlePasteError(error, intl, snackError));
                     break;
                 case ElementType.SPREADSHEET_CONFIG:
-                    duplicateSpreadsheetConfig(selectionForPaste.sourceItemUuid, directoryUuid).catch((error) =>
-                        handlePasteError(error, intl, snackError)
+                    duplicateSpreadsheetConfig(selectionForPaste.sourceItemUuid, directoryUuid).catch(
+                        (error: unknown) => handlePasteError(error, intl, snackError)
                     );
                     break;
                 case ElementType.SPREADSHEET_CONFIG_COLLECTION:
                     duplicateSpreadsheetConfigCollection(selectionForPaste.sourceItemUuid, directoryUuid).catch(
-                        (error) => handlePasteError(error, intl, snackError)
+                        (error: unknown) => handlePasteError(error, intl, snackError)
                     );
                     break;
                 default:
@@ -196,7 +196,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
             setDeleteError('');
             deleteElement(elementsUuid)
                 .then(handleCloseDialog)
-                .catch((error) => {
+                .catch((error: unknown) => {
                     handleDeleteError(setDeleteError, error, intl, snackError);
                 });
         },
@@ -341,7 +341,7 @@ export default function DirectoryTreeContextualMenu(props: Readonly<DirectoryTre
     const handleMoveDirectory = useCallback(
         (selectedDir: TreeViewFinderNodeProps[]) => {
             if (selectedDir.length === 1 && directory) {
-                moveElementsToDirectory([directory.elementUuid], selectedDir[0].id as UUID).catch((error) => {
+                moveElementsToDirectory([directory.elementUuid], selectedDir[0].id as UUID).catch((error: unknown) => {
                     if (handleMoveDirectoryConflictError(error, snackError)) {
                         return;
                     }

--- a/src/utils/custom-hooks.ts
+++ b/src/utils/custom-hooks.ts
@@ -7,7 +7,7 @@
 
 import { useCallback, useState } from 'react';
 import { IntlShape, useIntl } from 'react-intl';
-import { CustomError, useSnackMessage } from '@gridsuite/commons-ui';
+import { useSnackMessage } from '@gridsuite/commons-ui';
 import { ErrorMessageByHttpError, SnackError } from '../components/utils/rest-errors';
 
 export type GenericFunction<T, TArgs extends unknown[] = any[]> = (...args: TArgs) => Promise<T>;
@@ -69,7 +69,7 @@ export const useDeferredFetch = <T, TArgs extends unknown[] = any[]>(
 export const useMultipleDeferredFetch = <T>(
     fetchFunction: GenericFunction<T>,
     onSuccess?: (data: T[]) => void,
-    onError?: (errors: CustomError[], params: unknown[][], intl: IntlShape, snackError: SnackError) => void
+    onError?: (errors: unknown[], params: unknown[][], intl: IntlShape, snackError: SnackError) => void
 ): [(paramsList: unknown[][]) => Promise<void>] => {
     const { snackError } = useSnackMessage();
     const intl = useIntl();
@@ -90,7 +90,7 @@ export const useMultipleDeferredFetch = <T>(
             );
 
             const successes: T[] = [];
-            const errors: CustomError[] = [];
+            const errors: unknown[] = [];
             results.forEach((result) => {
                 if (result.status === PromiseStatus.FULFILLED) {
                     successes.push(result.value.data);


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Some errors were typed as CustomError in catch clauses, which is a bad practice, errors can be of any type. Then, I had to improve type-checking inside handling functions.

