### PR TITLE
[GRD-3838] make upload file size limit configurable via apps-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.162.0",
+                "@gridsuite/commons-ui": "0.163.0",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^5.18.0",
                 "@mui/lab": "5.0.0-alpha.175",
@@ -3313,9 +3313,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.162.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.162.0.tgz",
-            "integrity": "sha512-dvj9pCBIiEymR83KMKvjszo0R8MqlebTFY5JoEuxyxkHNPbhwbhsL79kp0bldPUsJFWTcMhgtWUD8aarIYY2TA==",
+            "version": "0.163.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.163.0.tgz",
+            "integrity": "sha512-BJhhfym9cpUSmcErnntR7AUiBu3g4Xpduj5hp1Dr94dVAI1xRRV7jY6QzeF6e2dm6YePR9v5YEBZwO5GOiLSzQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.162.0",
+        "@gridsuite/commons-ui": "0.163.0",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^5.18.0",
         "@mui/lab": "5.0.0-alpha.175",

--- a/src/components/dialogs/commons/upload-new-case.tsx
+++ b/src/components/dialogs/commons/upload-new-case.tsx
@@ -7,26 +7,33 @@
 
 import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 import { Button, CircularProgress, Grid, Input } from '@mui/material';
 import { useController, useFormContext } from 'react-hook-form';
 import { ErrorInput, FieldConstants, FieldErrorAlert } from '@gridsuite/commons-ui';
 import type { UUID } from 'node:crypto';
 import { HTTP_CONNECTION_FAILED_MESSAGE, HTTP_UNPROCESSABLE_ENTITY_STATUS } from 'utils/UIconstants';
 import { createCaseWithoutDirectoryElementCreation, deleteCase } from '../../../utils/rest-api';
+import type { AppState, ExploreMetadata } from '../../../redux/types';
 
 export interface UploadNewCaseProps {
     isNewStudyCreation?: boolean;
     getCurrentCaseImportParams?: (uuid: UUID) => void;
 }
 
-const MAX_FILE_SIZE_IN_MO = 100;
-const MAX_FILE_SIZE_IN_BYTES = MAX_FILE_SIZE_IN_MO * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE_IN_MO = 100;
 
 export default function UploadNewCase({
     isNewStudyCreation = false,
     getCurrentCaseImportParams,
 }: Readonly<UploadNewCaseProps>) {
     const intl = useIntl();
+    const MAX_FILE_SIZE_IN_MO = useSelector((state: AppState) => {
+        const exploreApp = state.appsAndUrls.find((metadata) => metadata.name === 'Explore') as ExploreMetadata;
+        return exploreApp?.MaxFileSizeInMo ?? DEFAULT_MAX_FILE_SIZE_IN_MO;
+    });
+
+    const MAX_FILE_SIZE_IN_BYTES = MAX_FILE_SIZE_IN_MO * 1024 * 1024;
 
     const [caseFileLoading, setCaseFileLoading] = useState(false);
 

--- a/src/components/dialogs/commons/upload-new-case.tsx
+++ b/src/components/dialogs/commons/upload-new-case.tsx
@@ -10,30 +10,33 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { Button, CircularProgress, Grid, Input } from '@mui/material';
 import { useController, useFormContext } from 'react-hook-form';
-import { ErrorInput, FieldConstants, FieldErrorAlert } from '@gridsuite/commons-ui';
+import { ErrorInput, FieldConstants, FieldErrorAlert, isExploreMetadata } from '@gridsuite/commons-ui';
 import type { UUID } from 'node:crypto';
 import { HTTP_CONNECTION_FAILED_MESSAGE, HTTP_UNPROCESSABLE_ENTITY_STATUS } from 'utils/UIconstants';
 import { createCaseWithoutDirectoryElementCreation, deleteCase } from '../../../utils/rest-api';
-import type { AppState, ExploreMetadata } from '../../../redux/types';
+import type { AppState } from '../../../redux/types';
 
 export interface UploadNewCaseProps {
     isNewStudyCreation?: boolean;
     getCurrentCaseImportParams?: (uuid: UUID) => void;
 }
 
-const DEFAULT_MAX_FILE_SIZE_IN_MO = 100;
+const DEFAULT_MAX_FILE_SIZE_IN_MB = 100;
 
 export default function UploadNewCase({
     isNewStudyCreation = false,
     getCurrentCaseImportParams,
 }: Readonly<UploadNewCaseProps>) {
     const intl = useIntl();
-    const MAX_FILE_SIZE_IN_MO = useSelector((state: AppState) => {
-        const exploreApp = state.appsAndUrls.find((metadata) => metadata.name === 'Explore') as ExploreMetadata;
-        return exploreApp?.MaxFileSizeInMo ?? DEFAULT_MAX_FILE_SIZE_IN_MO;
-    });
 
-    const MAX_FILE_SIZE_IN_BYTES = MAX_FILE_SIZE_IN_MO * 1024 * 1024;
+    const appsAndUrls = useSelector((state: AppState) => state.appsAndUrls);
+
+    const maxFileSizeInMb = useMemo(() => {
+        const exploreMetadata = appsAndUrls.find(isExploreMetadata);
+        return exploreMetadata?.maxFileSizeInMb ?? DEFAULT_MAX_FILE_SIZE_IN_MB;
+    }, [appsAndUrls]);
+
+    const maxFileSizeInByte = maxFileSizeInMb * 1024 * 1024;
 
     const [caseFileLoading, setCaseFileLoading] = useState(false);
 
@@ -96,7 +99,7 @@ export default function UploadNewCase({
         if (files?.length) {
             const currentFile = files[0];
 
-            if (currentFile.size <= MAX_FILE_SIZE_IN_BYTES) {
+            if (currentFile.size <= maxFileSizeInByte) {
                 onValueChange(currentFile);
 
                 if (isNewStudyCreation) {
@@ -130,7 +133,7 @@ export default function UploadNewCase({
                                 id: 'uploadFileExceedingLimitSizeErrorMsg',
                             },
                             {
-                                maxSize: MAX_FILE_SIZE_IN_MO,
+                                maxSize: maxFileSizeInMb,
                             }
                         )
                         .toString(),

--- a/src/redux/types.d.ts
+++ b/src/redux/types.d.ts
@@ -78,3 +78,8 @@ export interface AppState extends CommonStoreState {
     itemSelectionForCopy: ItemSelectionForCopy;
     reorderedColumns: string[];
 }
+
+export type ExploreMetadata = Metadata & {
+    name: 'Explore';
+    MaxFileSizeInMo?: number;
+};

--- a/src/redux/types.d.ts
+++ b/src/redux/types.d.ts
@@ -78,8 +78,3 @@ export interface AppState extends CommonStoreState {
     itemSelectionForCopy: ItemSelectionForCopy;
     reorderedColumns: string[];
 }
-
-export type ExploreMetadata = Metadata & {
-    name: 'Explore';
-    MaxFileSizeInMo?: number;
-};


### PR DESCRIPTION
This PR moves the upload file size limit from a hardcoded value to the apps-metadata configuration.

The maximum allowed file size is now dynamically retrieved from the Explore app metadata (maxFileSizeInMb).
If the metadata is missing, a default value of 100 MB is used to ensure backward compatibility.

