### PR TITLE
Add persistCase API and refactor create-case logic

### DIFF
--- a/src/components/dialogs/commons/upload-new-case.tsx
+++ b/src/components/dialogs/commons/upload-new-case.tsx
@@ -23,16 +23,12 @@ import { createCaseWithoutDirectoryElementCreation, deleteCase } from '../../../
 import type { AppState } from '../../../redux/types';
 
 export interface UploadNewCaseProps {
-    isNewStudyCreation?: boolean;
     getCurrentCaseImportParams?: (uuid: UUID) => void;
 }
 
 const DEFAULT_MAX_FILE_SIZE_IN_MB = 100;
 
-export default function UploadNewCase({
-    isNewStudyCreation = false,
-    getCurrentCaseImportParams,
-}: Readonly<UploadNewCaseProps>) {
+export default function UploadNewCase({ getCurrentCaseImportParams }: Readonly<UploadNewCaseProps>) {
     const intl = useIntl();
 
     const appsAndUrls = useSelector((state: AppState) => state.appsAndUrls);
@@ -103,28 +99,26 @@ export default function UploadNewCase({
             if (currentFile.size <= maxFileSizeInByte) {
                 onValueChange(currentFile);
 
-                if (isNewStudyCreation) {
-                    // Create new case
-                    setCaseFileLoading(true);
-                    createCaseWithoutDirectoryElementCreation(currentFile)
-                        .then((newCaseUuid) => {
-                            const prevCaseUuid = getValues(FieldConstants.CASE_UUID);
+                // Create new case
+                setCaseFileLoading(true);
+                createCaseWithoutDirectoryElementCreation(currentFile)
+                    .then((newCaseUuid) => {
+                        const prevCaseUuid = getValues(FieldConstants.CASE_UUID);
 
-                            if (prevCaseUuid && prevCaseUuid !== newCaseUuid) {
-                                deleteCase(prevCaseUuid);
-                            }
+                        if (prevCaseUuid && prevCaseUuid !== newCaseUuid) {
+                            deleteCase(prevCaseUuid);
+                        }
 
-                            onCaseUuidChange(newCaseUuid);
+                        onCaseUuidChange(newCaseUuid);
 
-                            if (getCurrentCaseImportParams) {
-                                getCurrentCaseImportParams(newCaseUuid);
-                            }
-                        })
-                        .catch(handleUploadCaseError)
-                        .finally(() => {
-                            setCaseFileLoading(false);
-                        });
-                }
+                        if (getCurrentCaseImportParams) {
+                            getCurrentCaseImportParams(newCaseUuid);
+                        }
+                    })
+                    .catch(handleUploadCaseError)
+                    .finally(() => {
+                        setCaseFileLoading(false);
+                    });
             } else {
                 setError(FieldConstants.CASE_FILE, {
                     type: 'caseFileSize',

--- a/src/components/dialogs/create-case-dialog/create-case-dialog-utils.ts
+++ b/src/components/dialogs/create-case-dialog/create-case-dialog-utils.ts
@@ -6,15 +6,18 @@
  */
 
 import { FieldConstants, MAX_CHAR_DESCRIPTION, yupConfig as yup } from '@gridsuite/commons-ui';
+import type { UUID } from 'node:crypto';
 
 export const getCreateCaseDialogFormValidationDefaultValues = () => ({
     [FieldConstants.CASE_NAME]: '',
     [FieldConstants.DESCRIPTION]: '',
     [FieldConstants.CASE_FILE]: null,
+    [FieldConstants.CASE_UUID]: null,
 });
 
 export const createCaseDialogFormValidationSchema = yup.object().shape({
     [FieldConstants.CASE_NAME]: yup.string().trim().required('nameEmpty'),
     [FieldConstants.DESCRIPTION]: yup.string().max(MAX_CHAR_DESCRIPTION),
     [FieldConstants.CASE_FILE]: yup.mixed<File>().nullable().required(),
+    [FieldConstants.CASE_UUID]: yup.string<UUID>().uuid().required(),
 });

--- a/src/components/dialogs/create-case-dialog/create-case-dialog.tsx
+++ b/src/components/dialogs/create-case-dialog/create-case-dialog.tsx
@@ -20,7 +20,8 @@ import {
     useConfidentialityWarning,
     useSnackMessage,
 } from '@gridsuite/commons-ui';
-import { createCase } from '../../../utils/rest-api';
+import type { UUID } from 'node:crypto';
+import { persistCase } from '../../../utils/rest-api';
 import { addUploadingElement, removeUploadingElement } from '../../../redux/actions';
 import UploadNewCase from '../commons/upload-new-case';
 import {
@@ -35,6 +36,7 @@ interface IFormData {
     [FieldConstants.CASE_NAME]: string;
     [FieldConstants.DESCRIPTION]?: string;
     [FieldConstants.CASE_FILE]: File | null;
+    [FieldConstants.CASE_UUID]: UUID | null;
 }
 
 export interface CreateCaseDialogProps {
@@ -61,7 +63,7 @@ export default function CreateCaseDialog({ onClose, open }: Readonly<CreateCaseD
     const activeDirectory = useSelector((state: AppState) => state.activeDirectory);
     const userId = useSelector((state: AppState) => state.user?.profile.sub);
 
-    const handleCreateNewCase = ({ caseName, description, caseFile }: IFormData): void => {
+    const handleCreateNewCase = ({ caseName, description, caseUuid }: IFormData): void => {
         const uploadingCase: UploadingElement = {
             // @ts-expect-error: TODO wrong ID here
             id: keyGenerator(),
@@ -74,7 +76,7 @@ export default function CreateCaseDialog({ onClose, open }: Readonly<CreateCaseD
         };
 
         // @ts-expect-error TODO: manage null cases here
-        createCase(caseName, description ?? '', caseFile, activeDirectory)
+        persistCase(caseName, description ?? '', caseUuid, activeDirectory)
             .then(onClose)
             .catch((err) => {
                 dispatch(removeUploadingElement(uploadingCase));

--- a/src/components/dialogs/create-study-dialog/create-study-dialog.tsx
+++ b/src/components/dialogs/create-study-dialog/create-study-dialog.tsx
@@ -247,7 +247,7 @@ export default function CreateStudyDialog({ open, onClose, providedExistingCase 
                     dialogMessageLabel="moveItemContentText"
                 />
             ) : (
-                <UploadNewCase isNewStudyCreation getCurrentCaseImportParams={getCurrentCaseImportParams} />
+                <UploadNewCase getCurrentCaseImportParams={getCurrentCaseImportParams} />
             )}
             <ImportParametersSection />
             <Grid pt={1}>

--- a/src/utils/rest-api.ts
+++ b/src/utils/rest-api.ts
@@ -13,14 +13,14 @@ import {
     fetchEnv,
     getRequestParamFromList,
     getUserToken,
-    hasElementPermission,
-    PermissionType,
     type GsLang,
     type GsTheme,
+    hasElementPermission,
     LAST_SELECTED_DIRECTORY,
     PARAM_DEVELOPER_MODE,
     PARAM_LANGUAGE,
     PARAM_THEME,
+    PermissionType,
 } from '@gridsuite/commons-ui';
 import type { LiteralUnion } from 'type-fest';
 import { IncomingHttpHeaders } from 'node:http';
@@ -282,6 +282,23 @@ export function createCase(name: string, description: string, file: Blob, parent
     return backendFetch(url, {
         method: 'post',
         body: formData,
+    });
+}
+
+export function persistCase(name: string, description: string, caseUuid: string, parentDirectoryUuid: UUID) {
+    console.info('Persist case %s with uuid %s', name, caseUuid);
+    const urlSearchParams = new URLSearchParams();
+    urlSearchParams.append('description', description);
+    urlSearchParams.append('caseUuid', caseUuid);
+    urlSearchParams.append('parentDirectoryUuid', parentDirectoryUuid);
+
+    const url = `${PREFIX_EXPLORE_SERVER_QUERIES}/v1/explore/cases/${encodeURIComponent(
+        name
+    )}/persist?${urlSearchParams.toString()}`;
+    console.debug(url);
+
+    return backendFetch(url, {
+        method: 'post',
     });
 }
 


### PR DESCRIPTION
## PR Summary
When importing a case, we want to have the same behavior when it's to create a study or to create a case. That mean we first import the case in the server with expiration and then we remove the expiration when we validate the form. So if there is an error in the case name, for example, the error is immediately displayed before form validation. 