### PR TITLE
chore: use load creation form from commons UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.178.0",
+                "@gridsuite/commons-ui": "0.180.0",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^5.18.0",
                 "@mui/lab": "5.0.0-alpha.175",
@@ -3313,9 +3313,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.178.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.178.0.tgz",
-            "integrity": "sha512-yjwAAqEHvjtxVG+sZYx8giLbiyi/lxAf7Z/6yMNcEsm+vVnMZfhj40Wk+s5pk5r7vvPr39zFDBzOAfpsP9CTTQ==",
+            "version": "0.180.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.180.0.tgz",
+            "integrity": "sha512-ksQ+DqLwu20AKPItIadC+GxZoMomW/uWmAd3z6/QOmODbGYeRuNaAnXIVc7bsBUE4QwMugSg/7M3j15OuE19ww==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.178.0",
+        "@gridsuite/commons-ui": "0.180.0",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^5.18.0",
         "@mui/lab": "5.0.0-alpha.175",

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -59,6 +59,15 @@ const EDITABLE_MODIFICATION_DIALOGS = new Map<ModificationType, SpecificModifica
             titleId: 'CreateSubstation',
             ModificationForm: SubstationCreationForm,
         },
+        ModificationType.LOAD_CREATION,
+        {
+            formSchema: substationCreationFormSchema,
+            dtoToForm: substationCreationDtoToForm,
+            formToDto: substationCreationFormToDto,
+            errorHeaderId: 'SubstationCreationError',
+            titleId: 'CreateSubstation',
+            ModificationForm: LoadDialogTabsContent,
+        },
     ],
 ]);
 

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -14,6 +14,12 @@ import { List, ListItem, ListItemButton } from '@mui/material';
 import {
     CustomMuiDialog,
     FieldConstants,
+    loadCreationDtoToForm,
+    loadCreationFormSchema,
+    loadCreationFormToDto,
+    loadCreationTabsInError,
+    LoadDialogHeader,
+    LoadDialogTabsContent,
     ModificationType,
     NetworkModificationMetadata,
     NO_ITEM_SELECTION_FOR_COPY,
@@ -45,7 +51,14 @@ const styles = {
 
 type SpecificModificationDialogProps = Pick<
     ModificationDialogProps<any, any>,
-    'formSchema' | 'dtoToForm' | 'formToDto' | 'errorHeaderId' | 'titleId' | 'ModificationForm'
+    | 'formSchema'
+    | 'dtoToForm'
+    | 'formToDto'
+    | 'errorHeaderId'
+    | 'titleId'
+    | 'ModificationForm'
+    | 'HeaderForm'
+    | 'tabsInError'
 >;
 
 const EDITABLE_MODIFICATION_DIALOGS = new Map<ModificationType, SpecificModificationDialogProps>([
@@ -59,14 +72,18 @@ const EDITABLE_MODIFICATION_DIALOGS = new Map<ModificationType, SpecificModifica
             titleId: 'CreateSubstation',
             ModificationForm: SubstationCreationForm,
         },
+    ],
+    [
         ModificationType.LOAD_CREATION,
         {
-            formSchema: substationCreationFormSchema,
-            dtoToForm: substationCreationDtoToForm,
-            formToDto: substationCreationFormToDto,
-            errorHeaderId: 'SubstationCreationError',
-            titleId: 'CreateSubstation',
+            formSchema: loadCreationFormSchema,
+            dtoToForm: loadCreationDtoToForm,
+            formToDto: loadCreationFormToDto,
+            errorHeaderId: 'LoadCreationError',
+            titleId: 'CreateLoad',
+            HeaderForm: LoadDialogHeader,
             ModificationForm: LoadDialogTabsContent,
+            tabsInError: loadCreationTabsInError,
         },
     ],
 ]);

--- a/src/components/dialogs/network-modification/simple-modification/ModificationDialog.tsx
+++ b/src/components/dialogs/network-modification/simple-modification/ModificationDialog.tsx
@@ -29,6 +29,7 @@ export interface ModificationDialogProps<FormData extends FieldValues, Modificat
     dtoToForm: (dto: ModificationData) => FormData;
     formToDto: (form: FormData) => Omit<ModificationData, 'uuid'>;
     errorHeaderId: string;
+    initialTabIndex?: number;
 }
 
 interface WithId {
@@ -45,9 +46,12 @@ export function ModificationDialog<FormData extends FieldValues, ModificationDat
     dtoToForm,
     formToDto,
     errorHeaderId,
+    initialTabIndex = 0,
 }: Readonly<ModificationDialogProps<FormData, ModificationData>>) {
     const { snackError } = useSnackMessage();
     const [modificationData, setModificationData] = useState<ModificationData>();
+    const [tabIndexesWithError, setTabIndexesWithError] = useState<number[]>([]);
+    const [tabIndex, setTabIndex] = useState<number>(initialTabIndex);
 
     const formMethods = useForm<FormData>({
         resolver: yupResolver(formSchema) as any, // really difficult to type with yup inferred types

--- a/src/components/dialogs/network-modification/simple-modification/ModificationDialog.tsx
+++ b/src/components/dialogs/network-modification/simple-modification/ModificationDialog.tsx
@@ -14,22 +14,27 @@ import {
     updateModification,
     useSnackMessage,
 } from '@gridsuite/commons-ui';
-import { FieldValues, useForm } from 'react-hook-form';
+import { FieldErrors, FieldValues, useForm } from 'react-hook-form';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ObjectSchema } from 'yup';
+
+export interface ModificationFormProps {
+    tabIndex: number;
+}
 
 export interface ModificationDialogProps<FormData extends FieldValues, ModificationData extends WithId> {
     open: CustomMuiDialogProps['open'];
     onClose: CustomMuiDialogProps['onClose'];
     titleId: CustomMuiDialogProps['titleId'];
     modificationUuid: UUID;
-    ModificationForm: FunctionComponent;
     formSchema: ObjectSchema<FormData>;
     dtoToForm: (dto: ModificationData) => FormData;
     formToDto: (form: FormData) => Omit<ModificationData, 'uuid'>;
     errorHeaderId: string;
-    initialTabIndex?: number;
+    HeaderForm?: FunctionComponent<any>;
+    ModificationForm: React.ComponentType<ModificationFormProps>;
+    tabsInError?: (errors: FieldErrors) => number[];
 }
 
 interface WithId {
@@ -46,12 +51,13 @@ export function ModificationDialog<FormData extends FieldValues, ModificationDat
     dtoToForm,
     formToDto,
     errorHeaderId,
-    initialTabIndex = 0,
+    HeaderForm,
+    tabsInError,
 }: Readonly<ModificationDialogProps<FormData, ModificationData>>) {
     const { snackError } = useSnackMessage();
     const [modificationData, setModificationData] = useState<ModificationData>();
     const [tabIndexesWithError, setTabIndexesWithError] = useState<number[]>([]);
-    const [tabIndex, setTabIndex] = useState<number>(initialTabIndex);
+    const [tabIndex, setTabIndex] = useState<number>(0);
 
     const formMethods = useForm<FormData>({
         resolver: yupResolver(formSchema) as any, // really difficult to type with yup inferred types
@@ -89,6 +95,18 @@ export function ModificationDialog<FormData extends FieldValues, ModificationDat
         [modificationData, formToDto, snackError, errorHeaderId]
     );
 
+    const onValidationError = (errors: FieldErrors) => {
+        const errorTabs = tabsInError ? tabsInError(errors) : [];
+        if (errorTabs.length > 0) {
+            setTabIndex(errorTabs[0]);
+        }
+        setTabIndexesWithError(errorTabs);
+    };
+
+    const headerAndTabs = HeaderForm ? (
+        <HeaderForm tabIndexesWithError={tabIndexesWithError} tabIndex={tabIndex} setTabIndex={setTabIndex} />
+    ) : null;
+
     return (
         <CustomMuiDialog
             open={open}
@@ -96,10 +114,12 @@ export function ModificationDialog<FormData extends FieldValues, ModificationDat
             formMethods={formMethods}
             onClose={onClose}
             onSave={onSubmit}
+            onValidationError={onValidationError}
             titleId={titleId}
+            subtitle={headerAndTabs}
             isDataFetching={!modificationData}
         >
-            <ModificationForm />
+            <ModificationForm tabIndex={tabIndex} />
         </CustomMuiDialog>
     );
 }


### PR DESCRIPTION
## PR Summary
LoadForm has moved to commons-ui and can be imported in grid-explore. This form can be opened with a composite modification.




