### PR TITLE
Add VOLTAGE_LEVEL_CREATION to composite modifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.177.0",
+                "@gridsuite/commons-ui": "0.178.0",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^5.18.0",
                 "@mui/lab": "5.0.0-alpha.175",
@@ -3313,9 +3313,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.177.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.177.0.tgz",
-            "integrity": "sha512-DH5ZfFlcduhnjnLCVduA2ASuFx/d3x0aawBCwlhmNUer3dZFWYh41xtnE93sev/P9KdMvgAUj3OEqzVwXVqNKQ==",
+            "version": "0.178.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.178.0.tgz",
+            "integrity": "sha512-yjwAAqEHvjtxVG+sZYx8giLbiyi/lxAf7Z/6yMNcEsm+vVnMZfhj40Wk+s5pk5r7vvPr39zFDBzOAfpsP9CTTQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.177.0",
+        "@gridsuite/commons-ui": "0.178.0",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^5.18.0",
         "@mui/lab": "5.0.0-alpha.175",

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -29,6 +29,10 @@ import {
     unscrollableDialogStyles,
     useModificationLabelComputer,
     useSnackMessage,
+    voltageLevelCreationDtoToForm,
+    VoltageLevelCreationForm,
+    voltageLevelCreationFormSchema,
+    voltageLevelCreationFormToDto,
     yupConfig as yup,
 } from '@gridsuite/commons-ui';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -51,31 +55,6 @@ type SpecificModificationDialogProps = Pick<
     ModificationDialogProps<any, any>,
     'formSchema' | 'dtoToForm' | 'formToDto' | 'errorHeaderId' | 'titleId' | 'ModificationForm'
 >;
-
-const EDITABLE_MODIFICATION_DIALOGS = new Map<ModificationType, SpecificModificationDialogProps>([
-    [
-        ModificationType.SUBSTATION_CREATION,
-        {
-            formSchema: substationCreationFormSchema,
-            dtoToForm: substationCreationDtoToForm,
-            formToDto: substationCreationFormToDto,
-            errorHeaderId: 'SubstationCreationError',
-            titleId: 'CreateSubstation',
-            ModificationForm: SubstationCreationForm,
-        },
-    ],
-    [
-        ModificationType.SUBSTATION_MODIFICATION,
-        {
-            formSchema: substationModificationFormSchema,
-            dtoToForm: (substationDto) => substationModificationDtoToForm(substationDto, false),
-            formToDto: substationModificationFormToDto,
-            errorHeaderId: 'SubstationModificationError',
-            titleId: 'ModifySubstation',
-            ModificationForm: SubstationModificationForm,
-        },
-    ],
-]);
 
 const schema = yup.object().shape({
     [FieldConstants.NAME]: yup.string().trim().required('nameEmpty'),
@@ -131,6 +110,46 @@ export default function CompositeModificationDialog({
     const nameError: any = errors[FieldConstants.NAME];
     const isValidating = errors.root?.isValidating;
 
+    const editableModificationDialogs = useMemo(
+        () =>
+            new Map<ModificationType, SpecificModificationDialogProps>([
+                [
+                    ModificationType.SUBSTATION_CREATION,
+                    {
+                        formSchema: substationCreationFormSchema,
+                        dtoToForm: substationCreationDtoToForm,
+                        formToDto: substationCreationFormToDto,
+                        errorHeaderId: 'SubstationCreationError',
+                        titleId: 'CreateSubstation',
+                        ModificationForm: SubstationCreationForm,
+                    },
+                ],
+                [
+                    ModificationType.SUBSTATION_MODIFICATION,
+                    {
+                        formSchema: substationModificationFormSchema,
+                        dtoToForm: (substationDto) => substationModificationDtoToForm(substationDto, false),
+                        formToDto: substationModificationFormToDto,
+                        errorHeaderId: 'SubstationModificationError',
+                        titleId: 'ModifySubstation',
+                        ModificationForm: SubstationModificationForm,
+                    },
+                ],
+                [
+                    ModificationType.VOLTAGE_LEVEL_CREATION,
+                    {
+                        formSchema: voltageLevelCreationFormSchema,
+                        dtoToForm: (dto) => voltageLevelCreationDtoToForm(dto, intl, false),
+                        formToDto: voltageLevelCreationFormToDto,
+                        errorHeaderId: 'VoltageLevelCreationError',
+                        titleId: 'CreateVoltageLevel',
+                        ModificationForm: VoltageLevelCreationForm,
+                    },
+                ],
+            ]),
+        [intl]
+    );
+
     const { computeLabel } = useModificationLabelComputer();
     const getModificationLabel = (modif: NetworkModificationMetadata) => {
         if (!modif) {
@@ -143,9 +162,12 @@ export default function CompositeModificationDialog({
         return intl.formatMessage({ id: `network_modifications.${modif.messageType}` }, labelData);
     };
 
-    const isModificationEditable = useCallback((modificationType: ModificationType) => {
-        return EDITABLE_MODIFICATION_DIALOGS.has(modificationType);
-    }, []);
+    const isModificationEditable = useCallback(
+        (modificationType: ModificationType) => {
+            return editableModificationDialogs.has(modificationType);
+        },
+        [editableModificationDialogs]
+    );
 
     const editModification = useCallback(
         async (modification: NetworkModificationMetadata) => {
@@ -246,7 +268,7 @@ export default function CompositeModificationDialog({
                     modificationUuid={selectedModification.uuid}
                     // We can force to not undefined because if there is a selectedModification it means it is editable
                     // and then a configuration will be associated
-                    {...EDITABLE_MODIFICATION_DIALOGS.get(selectedModification.type)!}
+                    {...editableModificationDialogs.get(selectedModification.type)!}
                 />
             )}
         </>


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
This pull request updates the way editable modification dialogs are managed in the `CompositeModificationDialog` component. The main change is moving the configuration map for editable dialogs from a static variable to a memoized hook, and adding support for voltage level creation dialogs. 