### PR TITLE
chore: use equipment deletion form from commons UI

### DIFF
--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -75,6 +75,8 @@ import {
     PARAM_THEME,
     errorsEn,
     errorsFr,
+    equipmentTypesEn,
+    equipmentTypesFr,
 } from '@gridsuite/commons-ui';
 import { IntlConfig, IntlProvider } from 'react-intl';
 import { BrowserRouter } from 'react-router';
@@ -237,6 +239,7 @@ const messages: Record<GsLangUser, IntlConfig['messages']> = {
         ...equipmentsEn,
         ...equipmentShortEn,
         ...equipmentTagEn,
+        ...equipmentTypesEn,
         ...csvEn,
         ...parametersEn,
         ...useUniqueNameValidationEn,
@@ -268,6 +271,7 @@ const messages: Record<GsLangUser, IntlConfig['messages']> = {
         ...equipmentsFr,
         ...equipmentShortFr,
         ...equipmentTagFr,
+        ...equipmentTypesFr,
         ...csvFr,
         ...parametersFr,
         ...useUniqueNameValidationFr,

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -13,6 +13,10 @@ import { useIntl } from 'react-intl';
 import { List, ListItem, ListItemButton } from '@mui/material';
 import {
     CustomMuiDialog,
+    equipmentDeletionDtoToForm,
+    equipmentDeletionFormToDto,
+    equipmentDeletionFormSchema,
+    EquipmentDeletionForm,
     FieldConstants,
     ModificationType,
     NetworkModificationMetadata,
@@ -53,6 +57,17 @@ type SpecificModificationDialogProps = Pick<
 >;
 
 const EDITABLE_MODIFICATION_DIALOGS = new Map<ModificationType, SpecificModificationDialogProps>([
+    [
+        ModificationType.EQUIPMENT_DELETION,
+        {
+            formSchema: equipmentDeletionFormSchema,
+            dtoToForm: equipmentDeletionDtoToForm,
+            formToDto: equipmentDeletionFormToDto,
+            errorHeaderId: 'UnableToDeleteEquipment',
+            titleId: 'DeleteEquipment',
+            ModificationForm: EquipmentDeletionForm,
+        },
+    ],
     [
         ModificationType.SUBSTATION_CREATION,
         {


### PR DESCRIPTION
## PR Summary
DeleteEquipmentForm has moved (and renamed to EquipmentDeletionForm) to commons-ui and can be imported in grid-explore. This form can be opened with a composite modification



