### PR TITLE
fix: dont show previous values while editing load modification

### DIFF
--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -187,7 +187,7 @@ export default function CompositeModificationDialog({
                     ModificationType.LOAD_MODIFICATION,
                     {
                         formSchema: loadModificationFormSchema,
-                        dtoToForm: loadModificationDtoToForm,
+                        dtoToForm: (loadDto) => loadModificationDtoToForm(loadDto, false),
                         formToDto: loadModificationFormToDto,
                         errorHeaderId: 'LoadModificationError',
                         titleId: 'ModifyLoad',


### PR DESCRIPTION
## PR Summary
Issue fixed: we must hide previous values for properties when we edit a load modification from the composite edition dialog.



