### PR TITLE
chore: rely on CustomAgGridTable default for stopEditingWhenCellsLoseFocus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.220.0",
+                "@gridsuite/commons-ui": "0.221.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3309,9 +3309,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.220.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.220.0.tgz",
-            "integrity": "sha512-+oR5Z6c2piRDQQUKMTDPTI8Ch7a3/r0a/UzvHcNOuj3765UFLNIO8SbTJj5XRS4EZGssyDh8sk5+ePlC/iun1w==",
+            "version": "0.221.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.221.0.tgz",
+            "integrity": "sha512-DxDTtFCBdk6VHAYX27XS01KJP6RYktvd1phaynl34Poc8hqMrlZdkNEYHR5rTq90L1bZdKdGQsluTxbZcUfZbQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.220.0",
+        "@gridsuite/commons-ui": "0.221.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
+++ b/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
@@ -127,7 +127,6 @@ export default function ExplicitNamingForm() {
                 }}
                 defaultColDef={defaultColDef}
                 alwaysShowVerticalScroll
-                stopEditingWhenCellsLoseFocus
                 csvProps={{
                     fileName: intl.formatMessage({ id: 'contingencyListCreation' }),
                     fileHeaders: csvFileHeaders,


### PR DESCRIPTION
## Summary

`stopEditingWhenCellsLoseFocus` now defaults to `true` in `CustomAgGridTable` (commons-ui), so the explicit prop here is redundant. Drops it from `ExplicitNamingForm`.

Depends on https://github.com/gridsuite/commons-ui/pull/1133 being merged and released.