### PR TITLE
Make name and description umodifiable in composite modification form

### DIFF
--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -380,6 +380,12 @@ export default function CompositeModificationDialog({
                 disabledSave={!!nameError || !!isValidating}
                 isDataFetching={isFetching}
                 unscrollableFullHeight
+                sx={{
+                    '.MuiDialog-paper': {
+                        width: '75vw',
+                        maxWidth: '75vw',
+                    },
+                }}
             >
                 {!isFetching && (
                     <Box sx={unscrollableDialogStyles.unscrollableContainer}>

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-form.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-form.tsx
@@ -7,8 +7,11 @@
 
 import { FieldConstants, TextInput, unscrollableDialogStyles } from '@gridsuite/commons-ui';
 import { Box } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 
 export default function CompositeModificationForm() {
+    const { getValues } = useFormContext();
+    const name = getValues(FieldConstants.NAME);
     return (
         <>
             <Box sx={unscrollableDialogStyles.unscrollableHeader}>
@@ -18,7 +21,9 @@ export default function CompositeModificationForm() {
                     formProps={{
                         disabled: true,
                         sx: {
-                            width: '50ch',
+                            minWidth: '50ch',
+                            width: `${String(name ?? '').length}ch`,
+                            maxWidth: '100%',
                         },
                     }}
                 />

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-form.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-form.tsx
@@ -17,6 +17,9 @@ export default function CompositeModificationForm() {
                     label="name"
                     formProps={{
                         disabled: true,
+                        sx: {
+                            width: '50ch',
+                        },
                     }}
                 />
             </Box>

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-form.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-form.tsx
@@ -5,31 +5,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {
-    UniqueNameInput,
-    ElementType,
-    FieldConstants,
-    DescriptionField,
-    unscrollableDialogStyles,
-} from '@gridsuite/commons-ui';
-import { useSelector } from 'react-redux';
-import { AppState } from 'redux/types';
-import Box from '@mui/material/Box';
+import { FieldConstants, TextInput, unscrollableDialogStyles } from '@gridsuite/commons-ui';
+import { Box } from '@mui/material';
 
 export default function CompositeModificationForm() {
-    const activeDirectory = useSelector((state: AppState) => state.activeDirectory);
     return (
         <>
             <Box sx={unscrollableDialogStyles.unscrollableHeader}>
-                <UniqueNameInput
+                <TextInput
                     name={FieldConstants.NAME}
-                    label="nameProperty"
-                    elementType={ElementType.MODIFICATION}
-                    activeDirectory={activeDirectory}
+                    label="name"
+                    formProps={{
+                        disabled: true,
+                    }}
                 />
             </Box>
             <Box sx={unscrollableDialogStyles.unscrollableHeader}>
-                <DescriptionField />
+                <TextInput
+                    name={FieldConstants.DESCRIPTION}
+                    label="description"
+                    formProps={{
+                        disabled: true,
+                    }}
+                />
             </Box>
         </>
     );


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Editing name and description from composite dialog take long time, since the whole modification is saved, the user can think that his modification didn't work and try to edit again before the request is done.
We disable this way of editing, user can always edit name and description from outside the composite dialog.



