### PR TITLE
Update network-modification table API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.211.0",
+                "@gridsuite/commons-ui": "0.213.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3309,9 +3309,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.211.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.211.0.tgz",
-            "integrity": "sha512-6v2ZSeiqh8DQPvzXHj/fz80zHZwE+oMrO8K1YEson4coqCGA05HuDU8eVeYlaljjY22pc+vf9wtHqOAnPbOMWg==",
+            "version": "0.213.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.213.0.tgz",
+            "integrity": "sha512-CNPmsHA/WGojJnrkVt2aH+x298xW87wE21fcU6aHcNTsArsEZSbd6oTRJ3NmXWUvj+lHO9GGpgiJtk+SIPB0YA==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.211.0",
+        "@gridsuite/commons-ui": "0.213.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Box from '@mui/material/Box';
 import { useForm } from 'react-hook-form';
@@ -25,7 +25,6 @@ import {
     loadModificationFormToDto,
     LoadForm,
     ModificationType,
-    NameHeaderProps,
     NetworkModificationMetadata,
     NO_ITEM_SELECTION_FOR_COPY,
     snackWithFallback,
@@ -51,8 +50,8 @@ import {
     VoltageLevelCreationForm,
     voltageLevelCreationFormSchema,
     voltageLevelCreationFormToDto,
-    NetworkModificationEditorNameHeader,
-    NameCell,
+    NameCellRenderer,
+    NameHeaderRenderer,
     voltageLevelModificationDtoToForm,
     VoltageLevelModificationForm,
     voltageLevelModificationFormSchema,
@@ -115,20 +114,19 @@ interface CompositeModificationDialogProps {
     broadcastChannel: BroadcastChannel;
 }
 
-const createBaseColumns = (
-    isRowDragDisabled: boolean,
-    modificationsCount: number,
-    nameHeaderProps: NameHeaderProps,
-    _setModifications: React.Dispatch<SetStateAction<ComposedModificationMetadata[]>>
-): ColumnDef<ComposedModificationMetadata>[] => [
+// Rename a (nested) composite modification. Only the name and description are sent;
+// the content is left null so the backend keeps the existing sub-modifications.
+const renameCompositeModification = (modification: ComposedModificationMetadata, newName: string) =>
+    saveCompositeModification(modification.uuid, null, newName, modification.description);
+
+const BASE_COLUMNS: ColumnDef<ComposedModificationMetadata>[] = [
     {
         id: BASE_MODIFICATION_TABLE_COLUMNS.NAME.id,
-        header: () => (
-            <NetworkModificationEditorNameHeader modificationCount={modificationsCount} {...nameHeaderProps} />
-        ),
-        cell: ({ row }) => <NameCell row={row} />,
+        header: NameHeaderRenderer,
+        cell: NameCellRenderer,
         meta: {
             cellStyle: networkModificationTableStyles.columnCell.modificationName,
+            onChange: renameCompositeModification,
         },
         minSize: 160,
     },
@@ -395,7 +393,7 @@ export default function CompositeModificationDialog({
                             notificationMessageId="notificationMessageId"
                             isFetchingModifications={false}
                             pendingState={false}
-                            createAllColumns={createBaseColumns}
+                            columns={BASE_COLUMNS}
                             highlightedModificationUuid={null}
                             studyUuid={null}
                         />

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -28,6 +28,7 @@ import {
     NetworkModificationMetadata,
     NO_ITEM_SELECTION_FOR_COPY,
     snackWithFallback,
+    updateNetworkModificationsMetadata,
     byFilterDeletionDtoToForm,
     byFilterDeletionFormSchema,
     byFilterDeletionFormToDto,
@@ -114,10 +115,10 @@ interface CompositeModificationDialogProps {
     broadcastChannel: BroadcastChannel;
 }
 
-// Rename a (nested) composite modification. Only the name and description are sent;
-// the content is left null so the backend keeps the existing sub-modifications.
+// Rename a (nested) composite modification. It is a network modification inside the parent composite
+// (not a directory element), so its metadata is updated directly on the network-modification-server.
 const renameCompositeModification = (modification: ComposedModificationMetadata, newName: string) =>
-    saveCompositeModification(modification.uuid, null, newName, modification.description);
+    updateNetworkModificationsMetadata([modification.uuid], { name: newName, type: modification.type });
 
 const BASE_COLUMNS: ColumnDef<ComposedModificationMetadata>[] = [
     {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -99,6 +99,7 @@
     "contingencyListCreationError": "An error occurred while creating the contingency list: {name}",
     "contingencyListEditingError": "An error occurred while editing the contingency list: {name}",
     "compositeModificationEditingError": "An error occurred while editing the composite modification: {name}",
+    "networkModificationRenamingError": "An error occurred while renaming the modification",
     "contingencyListCreation": "contingencyListCreation",
     "equipmentID": "Equipment ID",
     "equipments": "Equipments",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -98,6 +98,7 @@
     "contingencyListCreationError": "Une erreur est survenue lors de la création de la liste d'aléas : {name}",
     "contingencyListEditingError": "Une erreur est survenue lors de l'édition de la liste d'aléas : {name}",
     "compositeModificationEditingError": "Une erreur est survenue lors de l'édition de la modification composite : {name}",
+    "networkModificationRenamingError": "Une erreur est survenue lors du renommage de la modification",
     "contingencyListCreation": "creationListeAleas",
     "equipmentID": "ID d'ouvrage",
     "equipments": "Ouvrages",

--- a/src/utils/rest-api.ts
+++ b/src/utils/rest-api.ts
@@ -596,12 +596,7 @@ export function fetchCompositeModificationContent(id: string) {
     });
 }
 
-export function saveCompositeModification(
-    id: string,
-    moidificationUuids: UUID[] | null,
-    name: string,
-    description?: string
-) {
+export function saveCompositeModification(id: string, moidificationUuids: UUID[], name: string, description?: string) {
     const urlSearchParams = new URLSearchParams();
     urlSearchParams.append('name', name);
     urlSearchParams.append('description', description ?? '');

--- a/src/utils/rest-api.ts
+++ b/src/utils/rest-api.ts
@@ -596,7 +596,12 @@ export function fetchCompositeModificationContent(id: string) {
     });
 }
 
-export function saveCompositeModification(id: string, moidificationUuids: UUID[], name: string, description?: string) {
+export function saveCompositeModification(
+    id: string,
+    moidificationUuids: UUID[] | null,
+    name: string,
+    description?: string
+) {
     const urlSearchParams = new URLSearchParams();
     urlSearchParams.append('name', name);
     urlSearchParams.append('description', description ?? '');


### PR DESCRIPTION
## Summary

Adapts `CompositeModificationDialog` to the network-modification table that now lives in commons-ui, and enables inline renaming of composite modifications from that table.

- Migrates to the current `NetworkModificationsTable` API: the table takes a pre-built `columns` array instead of the former `createAllColumns` factory; the name column uses commons-ui's `NameHeaderRenderer` / `NameCellRenderer`.
- The name column's `onChange` callback renames a composite modification through `updateNetworkModificationsMetadata` (added in the commons-ui companion PR): a modification nested inside a composite is a network modification, not a directory element, so its metadata is updated directly on the network-modification-server.
- Adds the `networkModificationRenamingError` message shown by the cell on failure.

Companion PRs:
- commons-ui: https://github.com/gridsuite/commons-ui/pull/1132
- gridstudy-app: https://github.com/gridsuite/gridstudy-app/pull/3945
