### PR TITLE
fix(explicit-naming): force contingency name cell data type for CSV import

### DIFF
--- a/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
+++ b/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
@@ -62,6 +62,8 @@ export default function ExplicitNamingForm() {
             {
                 headerName: intl.formatMessage({ id: 'elementName' }),
                 field: FieldConstants.CONTINGENCY_NAME,
+                // force the data type instead of letting AG Grid infer it from the (CSV) cell values
+                cellDataType: 'text',
                 editable: true,
             },
         ],


### PR DESCRIPTION
## Summary

The explicit naming contingency list table imports CSV data into an AG Grid. The editable name column did not declare a `cellDataType`, so AG Grid inferred its type from the cell values, mistyping the column when the imported CSV provides unexpected values.

Force `CONTINGENCY_NAME` → `cellDataType: text` instead of relying on inference.