### PR TITLE
Scroll to routed root directory at gridexplore opening

### DIFF
--- a/src/components/tree-views-container.tsx
+++ b/src/components/tree-views-container.tsx
@@ -594,7 +594,6 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
 
     const { loadPath } = useDirectoryPathLoader();
 
-    // The directory the tree should scroll to. Setting it (re)schedules the scroll declaratively below.
     const [directoryToScroll, setDirectoryToScroll] = useState<UUID | undefined>(undefined);
 
     useEffect(() => {
@@ -603,8 +602,6 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
         }
         // Even if the directoryHtmlElement below exists, there are still new renders that will break the scroll on nested directories.
         // Using a delay with timeout is not clean but is the only short and working solution we found.
-        // The cleanup cancels the pending scroll when the target changes or on unmount, so only the
-        // latest directory selection can trigger scrollIntoView.
         const timeout = setTimeout(() => {
             document.getElementById(directoryToScroll)?.scrollIntoView({
                 behavior: 'smooth',

--- a/src/components/tree-views-container.tsx
+++ b/src/components/tree-views-container.tsx
@@ -594,17 +594,26 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
 
     const { loadPath } = useDirectoryPathLoader();
 
-    const scrollTreeToDirectory = useCallback((directoryUuid: UUID) => {
+    // The directory the tree should scroll to. Setting it (re)schedules the scroll declaratively below.
+    const [directoryToScroll, setDirectoryToScroll] = useState<UUID | undefined>(undefined);
+
+    useEffect(() => {
+        if (!directoryToScroll) {
+            return undefined;
+        }
         // Even if the directoryHtmlElement below exists, there are still new renders that will break the scroll on nested directories.
         // Using a delay with timeout is not clean but is the only short and working solution we found.
-        setTimeout(() => {
-            document.getElementById(directoryUuid)?.scrollIntoView({
+        // The cleanup cancels the pending scroll when the target changes or on unmount, so only the
+        // latest directory selection can trigger scrollIntoView.
+        const timeout = setTimeout(() => {
+            document.getElementById(directoryToScroll)?.scrollIntoView({
                 behavior: 'smooth',
                 block: 'center',
                 inline: 'nearest',
             });
         }, 700);
-    }, []);
+        return () => clearTimeout(timeout);
+    }, [directoryToScroll]);
 
     /* The URL (sourceItemUuid) is the single source of truth: this is the ONLY place that turns it into
        `selectedDirectory`. Every user action just navigates, and the selection/content follows. */
@@ -628,7 +637,7 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
             if (selectedDirectoryRef.current?.elementUuid !== sourceItemUuid) {
                 dispatch(setSelectedDirectory(knownDirectory));
             }
-            scrollTreeToDirectory(knownDirectory.elementUuid);
+            setDirectoryToScroll(knownDirectory.elementUuid);
             return undefined;
         }
 
@@ -655,7 +664,7 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
                     const directoryInMap = treeDataRef.current?.mapData[lastDirectory.elementUuid];
                     if (directoryInMap) {
                         dispatch(setSelectedDirectory(directoryInMap));
-                        scrollTreeToDirectory(lastDirectory.elementUuid);
+                        setDirectoryToScroll(lastDirectory.elementUuid);
                     }
                 }
 
@@ -687,7 +696,7 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
         return () => {
             cancelled = true;
         };
-    }, [sourceItemUuid, treeData.initialized, loadPath, dispatch, snackError, scrollTreeToDirectory]);
+    }, [sourceItemUuid, treeData.initialized, loadPath, dispatch, snackError]);
 
     return (
         <>

--- a/src/components/tree-views-container.tsx
+++ b/src/components/tree-views-container.tsx
@@ -594,6 +594,18 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
 
     const { loadPath } = useDirectoryPathLoader();
 
+    const scrollTreeToDirectory = useCallback((directoryUuid: UUID) => {
+        // Even if the directoryHtmlElement below exists, there are still new renders that will break the scroll on nested directories.
+        // Using a delay with timeout is not clean but is the only short and working solution we found.
+        setTimeout(() => {
+            document.getElementById(directoryUuid)?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+                inline: 'nearest',
+            });
+        }, 700);
+    }, []);
+
     /* The URL (sourceItemUuid) is the single source of truth: this is the ONLY place that turns it into
        `selectedDirectory`. Every user action just navigates, and the selection/content follows. */
     useEffect(() => {
@@ -610,12 +622,13 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
             return undefined;
         }
 
-        // Fast path: directory already loaded (tree/breadcrumb click) → select it, no fetch needed.
+        // Fast path: directory already loaded (root, or tree/breadcrumb click) → select it, no fetch needed.
         const knownDirectory = treeDataRef.current?.mapData[sourceItemUuid];
         if (knownDirectory) {
             if (selectedDirectoryRef.current?.elementUuid !== sourceItemUuid) {
                 dispatch(setSelectedDirectory(knownDirectory));
             }
+            scrollTreeToDirectory(knownDirectory.elementUuid);
             return undefined;
         }
 
@@ -642,18 +655,7 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
                     const directoryInMap = treeDataRef.current?.mapData[lastDirectory.elementUuid];
                     if (directoryInMap) {
                         dispatch(setSelectedDirectory(directoryInMap));
-                        // Even if the directoryHtmlElement below exists, there are still new renders that will break the scroll on nested directories.
-                        // Using a delay with timeout is not clean but is the only short and working solution we found.
-                        setTimeout(() => {
-                            const directoryHtmlElement = document.getElementById(lastDirectory.elementUuid);
-                            if (directoryHtmlElement) {
-                                directoryHtmlElement.scrollIntoView({
-                                    behavior: 'smooth',
-                                    block: 'center',
-                                    inline: 'nearest',
-                                });
-                            }
-                        }, 500);
+                        scrollTreeToDirectory(lastDirectory.elementUuid);
                     }
                 }
 
@@ -685,7 +687,7 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
         return () => {
             cancelled = true;
         };
-    }, [sourceItemUuid, treeData.initialized, loadPath, dispatch, snackError]);
+    }, [sourceItemUuid, treeData.initialized, loadPath, dispatch, snackError, scrollTreeToDirectory]);
 
     return (
         <>


### PR DESCRIPTION
Deep-linking to a root directory (or any already-loaded directory) goes through the **fast path** of the URL resolution effect (`tree-views-container.tsx`), which only selected the directory without scrolling the tree to it. As a result, opening GridExplore on a routed root element did not scroll the tree to it.

This drives the tree scroll declaratively: the URL resolution effect sets a `directoryToScroll` state from **both** the fast path and the slow path, and a dedicated effect performs the delayed `scrollIntoView`, so routed root elements are scrolled into view too.

The scroll effect's cleanup cancels the pending timeout when the target changes or on unmount, so an older pending scroll can no longer fire after a newer directory selection.

Also increase the delay to 700.
