### PR TITLE
Migrate explicit naming CSV import to CsvPicker requiredColumns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.242.0",
+                "@gridsuite/commons-ui": "0.243.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3354,9 +3354,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.242.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.242.0.tgz",
-            "integrity": "sha512-6Tkjv0ez5uIoImh6NXEYu+OnwHUm+paGXtWwVarlRoRI+BycI2PMztPPRBV7wFv5vaZgdkeWS/J7mIYY1iU0Kw==",
+            "version": "0.243.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.243.0.tgz",
+            "integrity": "sha512-OJfeSmbVVNbVwlx+/GiSsFJRH9y3ugBb1a0NXfzoNSDo2O8Tc6lX/dDhbwm92PQik9S2ncXw+FgUj9IGoiqNbg==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^35.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.242.0",
+        "@gridsuite/commons-ui": "0.243.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
+++ b/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
@@ -137,7 +137,7 @@ export default function ExplicitNamingForm() {
                 <Grid>
                     <CsvPicker<Record<string, string>>
                         label="UploadCSV"
-                        header={csvFileHeaders}
+                        requiredColumns={csvFileHeaders}
                         language={languageLocal}
                         selectedFile={selectedFile}
                         onFileChange={setSelectedFile}


### PR DESCRIPTION
## Context

gridsuite/commons-ui#1217 reworks `CsvPicker` validation: the `header` prop is removed and replaced by a single `requiredColumns: string[]` prop (the file is accepted as soon as it contains every required column, in any order; columns matching none of them are ignored). Removing `header` is a breaking change that every `CsvPicker` consumer must adapt to.

## Change

Adapt the explicit naming contingency list import (`explicit-naming-form.tsx`) to the new API: pass the expected columns through `requiredColumns` instead of the removed `header` prop. Behaviour is unchanged — the same column list is still required.

## Dependency

Requires gridsuite/commons-ui#1217 (`requiredColumns` option of `CsvPicker`) to be merged and released first.
