### PR TITLE
Move the generate-template button above the explicit naming table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.243.0",
+                "@gridsuite/commons-ui": "0.246.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3354,9 +3354,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.243.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.243.0.tgz",
-            "integrity": "sha512-OJfeSmbVVNbVwlx+/GiSsFJRH9y3ugBb1a0NXfzoNSDo2O8Tc6lX/dDhbwm92PQik9S2ncXw+FgUj9IGoiqNbg==",
+            "version": "0.246.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.246.0.tgz",
+            "integrity": "sha512-W+AUcqzdo0KsgshX8gWJVpcrasTplwoDjPzSUR4EspjftUZFZRBQDZB43sG2nbiQ7HFe1O2S6zdKWDDAqLu87A==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^35.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.243.0",
+        "@gridsuite/commons-ui": "0.246.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
+++ b/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
@@ -134,7 +134,7 @@ export default function ExplicitNamingForm() {
             <Grid>
                 <DescriptionField />
             </Grid>
-            <Grid container justifyContent="space-between" alignItems="center">
+            <Grid container spacing={2} justifyContent="space-between" alignItems="center">
                 <Grid>
                     <CsvDownloadButton
                         data={getTemplateData}

--- a/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
+++ b/src/components/dialogs/contingency-list/explicit-naming/explicit-naming-form.tsx
@@ -10,6 +10,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { FieldValues, useFormContext, UseFieldArrayReturn } from 'react-hook-form';
 import { v4 as uuid4 } from 'uuid';
 import {
+    CsvDownloadButton,
     CsvPicker,
     CustomAgGridTable,
     DescriptionField,
@@ -130,11 +131,20 @@ export default function ExplicitNamingForm() {
                     activeDirectory={activeDirectory}
                 />
             </Grid>
+            <Grid>
+                <DescriptionField />
+            </Grid>
             <Grid container justifyContent="space-between" alignItems="center">
                 <Grid>
-                    <DescriptionField />
+                    <CsvDownloadButton
+                        data={getTemplateData}
+                        fileName={intl.formatMessage({ id: 'contingencyListCreation' })}
+                        language={languageLocal}
+                        labelId="GenerateCSV"
+                        variant="contained"
+                    />
                 </Grid>
-                <Grid>
+                <Grid sx={{ flex: 1, minWidth: 0 }}>
                     <CsvPicker<Record<string, string>>
                         label="UploadCSV"
                         header={csvFileHeaders}
@@ -172,7 +182,6 @@ export default function ExplicitNamingForm() {
                     csvProps={{
                         fileName: intl.formatMessage({ id: 'contingencyListCreation' }),
                         language: languageLocal,
-                        getTemplateData,
                         getTableData,
                     }}
                 />


### PR DESCRIPTION
## Change

Follow-up to gridsuite/commons-ui#1219 (CSV buttons rework). On the explicit naming contingency list form:

- Render the contained **"Generate template"** button on its own row above the table (it no longer comes from the bottom toolbar), next to the import button.
- The imported file name truncates (single line + tooltip) so it no longer pushes the row to a new line.
- Restore the row spacing lost when the root `Grid` container was replaced by a `Stack`: a nested `Grid` container only inherits the spacing CSS variables from a parent `Grid` container, so the row now declares `spacing` explicitly.

## Dependency

Requires gridsuite/commons-ui#1219 (exported `CsvDownloadButton`, `CsvProps` without `getTemplateData`) to be merged and released first.

