### PR TITLE
chore(LineModification): use form from commons-UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.249.0",
+                "@gridsuite/commons-ui": "0.250.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3354,9 +3354,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.249.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.249.0.tgz",
-            "integrity": "sha512-lPP/YexCpIGcp2mgOEx/WwW4zKWTc3w7fn6pUYVcXQM7OWRKx11rE2En8q2PgqY/7j1bv634M25duhTFxd/Kxg==",
+            "version": "0.250.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.250.0.tgz",
+            "integrity": "sha512-OmHgu8rp2L1w1wIXpXIyzdhHJ/iZh6ZDwSPuZnXaHC+xU1T1KXS3C4vciMtXQJCZV23ycRMFec4ogw6xU7Z6sA==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^35.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.249.0",
+        "@gridsuite/commons-ui": "0.250.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
+++ b/src/components/dialogs/network-modification/composite-modification/composite-modification-dialog.tsx
@@ -88,6 +88,9 @@ import {
     lineCreationFormSchema,
     lineCreationDtoToForm,
     lineCreationFormToDto,
+    lineModificationFormSchema,
+    lineModificationDtoToForm,
+    lineModificationFormToDto,
 } from '@gridsuite/commons-ui';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -233,6 +236,19 @@ export default function CompositeModificationDialog({
                         ModificationForm: LineForm,
                         isModification: false,
                         removeOptional: false,
+                    },
+                ],
+                [
+                    ModificationType.LINE_MODIFICATION,
+                    {
+                        formSchema: lineModificationFormSchema,
+                        dtoToForm: (lineDto) => lineModificationDtoToForm(lineDto, false),
+                        formToDto: (lineDto) => lineModificationFormToDto(lineDto, intl),
+                        errorHeaderId: 'LineModificationError',
+                        titleId: 'ModifyLine',
+                        ModificationForm: LineForm,
+                        isModification: true,
+                        removeOptional: true,
                     },
                 ],
                 [


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
LineModification form is now supported in composite modifications dialog. Requires https://github.com/gridsuite/commons-ui/pull/1232


