### PR TITLE
Fix unreliable auto-scroll to the selected directory

### DIFF
--- a/src/components/custom-tree-item.tsx
+++ b/src/components/custom-tree-item.tsx
@@ -21,7 +21,6 @@ export type CustomTreeItemProps = {
     onExpand: (itemId: UUID) => void;
     onSelect: (itemId: UUID) => void;
     onContextMenu: (event: any, nodeId: UUID, anchorReference: PopoverReference) => void;
-    // Directory this item should scroll itself to when (and as soon as) it is mounted in the DOM
     directoryToScroll?: UUID;
     onScrolledToDirectory?: () => void;
 };
@@ -81,6 +80,10 @@ function CustomTreeItem(props: CustomTreeItemProps) {
         }
     }, [isMenuOpen, setHover]);
 
+    // A ref, not an effect: MUI mounts a group's items after the expansion state that revealed them, so no state
+    // change signals that the target's DOM node exists — a callback ref does. React calls it with this item's root
+    // <li> on attach and with null on detach, and re-runs it when its identity changes. Here it depends on
+    // isScrollTarget, so a directory already mounted when it becomes the target is scrolled to as well.
     const isScrollTarget = directoryToScroll === node.elementUuid;
     const handleScrollTargetRef = useScrollIntoViewRef(isScrollTarget, onScrolledToDirectory);
 

--- a/src/components/custom-tree-item.tsx
+++ b/src/components/custom-tree-item.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { forwardRef, MouseEventHandler, Ref, useCallback, useEffect, useState } from 'react';
+import { MouseEventHandler, useCallback, useEffect, useState } from 'react';
 import type { UUID } from 'node:crypto';
 import { PopoverReference } from '@mui/material';
 import { TreeItem, TreeItemSlotProps } from '@mui/x-tree-view';
@@ -14,16 +14,20 @@ import { useSelector } from 'react-redux';
 import { AppState } from '../redux/types';
 import { styles } from './treeview-utils';
 import CustomTreeItemLabel from './custom-tree-item-label';
+import { useScrollIntoViewRef } from '../hooks/use-scroll-into-view-ref';
 
 export type CustomTreeItemProps = {
     node: ElementAttributes;
     onExpand: (itemId: UUID) => void;
     onSelect: (itemId: UUID) => void;
     onContextMenu: (event: any, nodeId: UUID, anchorReference: PopoverReference) => void;
+    // Directory this item should scroll itself to when (and as soon as) it is mounted in the DOM
+    directoryToScroll?: UUID;
+    onScrolledToDirectory?: () => void;
 };
 
-const CustomTreeItem = forwardRef(function CustomTreeItemInner(props: CustomTreeItemProps, ref: Ref<HTMLLIElement>) {
-    const { node, onExpand, onSelect, onContextMenu } = props;
+function CustomTreeItem(props: CustomTreeItemProps) {
+    const { node, onExpand, onSelect, onContextMenu, directoryToScroll, onScrolledToDirectory } = props;
     const activeDirectory = useSelector((state: AppState) => state.activeDirectory);
     const selectedDirectory = useSelector((state: AppState) => state.selectedDirectory);
 
@@ -77,9 +81,12 @@ const CustomTreeItem = forwardRef(function CustomTreeItemInner(props: CustomTree
         }
     }, [isMenuOpen, setHover]);
 
+    const isScrollTarget = directoryToScroll === node.elementUuid;
+    const handleScrollTargetRef = useScrollIntoViewRef(isScrollTarget, onScrolledToDirectory);
+
     return (
         <TreeItem
-            ref={ref}
+            ref={handleScrollTargetRef}
             id={node.elementUuid}
             itemId={node.elementUuid}
             onContextMenu={(e) => onContextMenu(e, node.elementUuid, 'anchorPosition')}
@@ -120,14 +127,11 @@ const CustomTreeItem = forwardRef(function CustomTreeItemInner(props: CustomTree
             {hasChildren &&
                 node.children
                     .filter((childNode) => !!childNode)
-                    .map((childNode) => (
-                        // @ts-ignore : TS issue with the ref
-                        <CustomTreeItem {...props} key={childNode.elementUuid} node={childNode} />
-                    ))}
+                    .map((childNode) => <CustomTreeItem {...props} key={childNode.elementUuid} node={childNode} />)}
             {/* Placeholder to simulate children so MUI TreeItem displays the expand icon before data is loaded */}
             {!hasChildren && hasSubdirectories && <span key="placeholder" style={{ display: 'none' }} />}
         </TreeItem>
     );
-});
+}
 
 export default CustomTreeItem;

--- a/src/components/directory-tree-view.tsx
+++ b/src/components/directory-tree-view.tsx
@@ -25,6 +25,8 @@ export interface DirectoryTreeViewProps {
         anchorReference: PopoverReference
     ) => void;
     onDirectoryUpdate: (nodeId: UUID, isClose: boolean, isDirectoryMoving: boolean) => void;
+    directoryToScroll?: UUID;
+    onScrolledToDirectory: () => void;
 }
 
 export default function DirectoryTreeView({
@@ -32,6 +34,8 @@ export default function DirectoryTreeView({
     mapData,
     onContextMenu,
     onDirectoryUpdate,
+    directoryToScroll,
+    onScrolledToDirectory,
 }: Readonly<DirectoryTreeViewProps>) {
     const navigate = useNavigate();
     const { uuid: urlElementUuid } = useParams<{ uuid?: string }>();
@@ -127,6 +131,8 @@ export default function DirectoryTreeView({
                     onExpand={handleIconClick}
                     onSelect={handleLabelClick}
                     onContextMenu={onContextMenu}
+                    directoryToScroll={directoryToScroll}
+                    onScrolledToDirectory={onScrolledToDirectory}
                 />
             )}
         </SimpleTreeView>

--- a/src/components/directory-tree-view.tsx
+++ b/src/components/directory-tree-view.tsx
@@ -26,7 +26,7 @@ export interface DirectoryTreeViewProps {
     ) => void;
     onDirectoryUpdate: (nodeId: UUID, isClose: boolean, isDirectoryMoving: boolean) => void;
     directoryToScroll?: UUID;
-    onScrolledToDirectory: () => void;
+    onScrolledToDirectory?: () => void;
 }
 
 export default function DirectoryTreeView({

--- a/src/components/tree-views-container.tsx
+++ b/src/components/tree-views-container.tsx
@@ -595,9 +595,7 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
     );
 
     const [directoryToScroll, setDirectoryToScroll] = useState<UUID | undefined>(undefined);
-
-    // The scroll itself is performed by the DirectoryTreeView owning the directory, once the whole
-    // path is loaded, expanded and rendered; it calls back here to clear the request.
+    // once scrolled, we reset the state
     const handleScrolledToDirectory = useCallback(() => setDirectoryToScroll(undefined), []);
 
     // TODO TypeScript say that treeData.mapData is never falsy?...

--- a/src/components/tree-views-container.tsx
+++ b/src/components/tree-views-container.tsx
@@ -594,6 +594,12 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
         [handleCloseDirectoryMenu, openDialog]
     );
 
+    const [directoryToScroll, setDirectoryToScroll] = useState<UUID | undefined>(undefined);
+
+    // The scroll itself is performed by the DirectoryTreeView owning the directory, once the whole
+    // path is loaded, expanded and rendered; it calls back here to clear the request.
+    const handleScrolledToDirectory = useCallback(() => setDirectoryToScroll(undefined), []);
+
     // TODO TypeScript say that treeData.mapData is never falsy?...
     const directoryViews = useMemo(
         () =>
@@ -605,30 +611,21 @@ export default function TreeViewsContainer({ sourceItemUuid }: { readonly source
                     mapData={treeDataRef.current?.mapData}
                     onContextMenu={onContextMenu}
                     onDirectoryUpdate={updateDirectoryTree}
+                    directoryToScroll={directoryToScroll}
+                    onScrolledToDirectory={handleScrolledToDirectory}
                 />
             )),
-        [onContextMenu, treeData.mapData, treeData.rootDirectories, updateDirectoryTree]
+        [
+            onContextMenu,
+            treeData.mapData,
+            treeData.rootDirectories,
+            updateDirectoryTree,
+            directoryToScroll,
+            handleScrolledToDirectory,
+        ]
     );
 
     const { loadPath } = useDirectoryPathLoader();
-
-    const [directoryToScroll, setDirectoryToScroll] = useState<UUID | undefined>(undefined);
-
-    useEffect(() => {
-        if (!directoryToScroll) {
-            return undefined;
-        }
-        // Even if the directoryHtmlElement below exists, there are still new renders that will break the scroll on nested directories.
-        // Using a delay with timeout is not clean but is the only short and working solution we found.
-        const timeout = setTimeout(() => {
-            document.getElementById(directoryToScroll)?.scrollIntoView({
-                behavior: 'smooth',
-                block: 'center',
-                inline: 'nearest',
-            });
-        }, 700);
-        return () => clearTimeout(timeout);
-    }, [directoryToScroll]);
 
     /* The URL (sourceItemUuid) is the single source of truth: this is the ONLY place that turns it into
        `selectedDirectory`. Every user action just navigates, and the selection/content follows. */

--- a/src/hooks/use-scroll-into-view-ref.ts
+++ b/src/hooks/use-scroll-into-view-ref.ts
@@ -6,12 +6,8 @@
  */
 import { RefCallback, useCallback, useRef } from 'react';
 
-const RECHECK_INTERVAL_MS = 100;
-const MAX_CHECKS = 20;
-// Consecutive quiet samples required to declare the layout settled: a single quiet interval can
-// just be a lull between two async shifts (a transition ending, then a fetch response inserting
-// rows), two in a row make that much less likely.
-const QUIET_SAMPLES_TO_SETTLE = 2;
+const RECHECK_INTERVAL_MS = 200;
+const MAX_CHECKS = 10;
 
 /**
  * Returns a callback ref that, once its element is attached to the DOM, waits for the surrounding
@@ -68,7 +64,9 @@ export function useScrollIntoViewRef(isScrollTarget: boolean, onScrolled?: () =>
                 }
                 previous = current;
                 remainingChecks -= 1;
-                if (quietSamples >= QUIET_SAMPLES_TO_SETTLE || remainingChecks <= 0) {
+                // Two consecutive quiet samples, not one: a single quiet interval can just be a lull between two
+                // async shifts (a transition ending, then a fetch response inserting rows).
+                if (quietSamples >= 2 || remainingChecks <= 0) {
                     element.scrollIntoView({
                         // A smooth scroll is animated by the rendering pipeline, which is paused in
                         // a hidden tab (e.g. a link opened in a background tab): it would never move.

--- a/src/hooks/use-scroll-into-view-ref.ts
+++ b/src/hooks/use-scroll-into-view-ref.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { RefCallback, useCallback, useRef } from 'react';
+
+const RECHECK_INTERVAL_MS = 100;
+const MAX_CHECKS = 20;
+// Consecutive quiet samples required to declare the layout settled: a single quiet interval can
+// just be a lull between two async shifts (a transition ending, then a fetch response inserting
+// rows), two in a row make that much less likely.
+const QUIET_SAMPLES_TO_SETTLE = 2;
+
+/**
+ * Returns a callback ref that, once its element is attached to the DOM, waits for the surrounding
+ * layout to settle and then scrolls the element into view (centered).
+ *
+ * Scrolling to an element that appears asynchronously (deep link at load, search, breadcrumb…)
+ * cannot be done from a state-driven effect: the element may enter the DOM ticks after the state
+ * that caused it is applied (e.g. MUI group transitions mount their children later), so no React
+ * state change signals "the element now exists".
+ *
+ * @param isScrollTarget whether the element owning the ref is the one to scroll to
+ * @param onScrolled called after the scroll has been issued
+ */
+export function useScrollIntoViewRef(isScrollTarget: boolean, onScrolled?: () => void): RefCallback<HTMLElement> {
+    const pendingScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    return useCallback(
+        (element: HTMLElement | null) => {
+            clearTimeout(pendingScrollTimeoutRef.current);
+            if (!element || !isScrollTarget) {
+                return;
+            }
+            let scrollParent: HTMLElement | null = element.parentElement;
+            while (scrollParent && !/auto|scroll/.test(getComputedStyle(scrollParent).overflowY)) {
+                scrollParent = scrollParent.parentElement;
+            }
+            const contentPosition = () => {
+                const { top } = element.getBoundingClientRect();
+                return scrollParent
+                    ? {
+                          top: top - scrollParent.getBoundingClientRect().top + scrollParent.scrollTop,
+                          scrollHeight: scrollParent.scrollHeight,
+                      }
+                    : { top, scrollHeight: 0 };
+            };
+            /* The element mounts while its surroundings may still be settling: transitions are
+               resizing wrappers and pending fetches may still insert content, so a scroll issued
+               now would aim at a stale position — and a smooth animation cannot track a moving
+               target: restarting it stutters, correcting it afterwards double-jumps. So scroll
+               LAST: watch the element's position within the scrollable content — invariant under
+               scrolling itself, so a manual user scroll doesn't count as movement — and glide to
+               it in one go once it stopped moving (or when the bounded time budget runs out).
+               setTimeout (not requestAnimationFrame) so it also works in a hidden/background tab,
+               where rAF never fires. */
+            let previous: { top: number; scrollHeight: number } | undefined;
+            let quietSamples = 0;
+            let remainingChecks = MAX_CHECKS;
+            const scrollOnceLayoutSettles = () => {
+                if (!element.isConnected) {
+                    return; // the element left the DOM; a later ref attachment will retry
+                }
+                const current = contentPosition();
+                if (previous !== undefined) {
+                    const quiet = current.top === previous.top && current.scrollHeight === previous.scrollHeight;
+                    quietSamples = quiet ? quietSamples + 1 : 0;
+                }
+                previous = current;
+                remainingChecks -= 1;
+                if (quietSamples >= QUIET_SAMPLES_TO_SETTLE || remainingChecks <= 0) {
+                    element.scrollIntoView({
+                        // A smooth scroll is animated by the rendering pipeline, which is paused in
+                        // a hidden tab (e.g. a link opened in a background tab): it would never move.
+                        behavior: document.visibilityState === 'hidden' ? 'auto' : 'smooth',
+                        block: 'center',
+                        inline: 'nearest',
+                    });
+                    onScrolled?.();
+                    return;
+                }
+                pendingScrollTimeoutRef.current = setTimeout(scrollOnceLayoutSettles, RECHECK_INTERVAL_MS);
+            };
+            scrollOnceLayoutSettles();
+        },
+        [isScrollTarget, onScrolled]
+    );
+}

--- a/src/hooks/use-scroll-into-view-ref.ts
+++ b/src/hooks/use-scroll-into-view-ref.ts
@@ -33,6 +33,9 @@ export function useScrollIntoViewRef(isScrollTarget: boolean, onScrolled?: () =>
             if (!element || !isScrollTarget) {
                 return;
             }
+            // The nearest ancestor that actually scrolls. Not needed to scroll — scrollIntoView finds its own —
+            // but as the frame of reference for the position below: measured within that ancestor's content, the
+            // position is invariant under scrolling, so a manual user scroll doesn't read as the layout moving.
             let scrollParent: HTMLElement | null = element.parentElement;
             while (scrollParent && !/auto|scroll/.test(getComputedStyle(scrollParent).overflowY)) {
                 scrollParent = scrollParent.parentElement;
@@ -46,15 +49,11 @@ export function useScrollIntoViewRef(isScrollTarget: boolean, onScrolled?: () =>
                       }
                     : { top, scrollHeight: 0 };
             };
-            /* The element mounts while its surroundings may still be settling: transitions are
-               resizing wrappers and pending fetches may still insert content, so a scroll issued
-               now would aim at a stale position — and a smooth animation cannot track a moving
-               target: restarting it stutters, correcting it afterwards double-jumps. So scroll
-               LAST: watch the element's position within the scrollable content — invariant under
-               scrolling itself, so a manual user scroll doesn't count as movement — and glide to
-               it in one go once it stopped moving (or when the bounded time budget runs out).
-               setTimeout (not requestAnimationFrame) so it also works in a hidden/background tab,
-               where rAF never fires. */
+            /* Why wait: transitions and pending fetches are still moving things, so a scroll issued now would aim at
+               a stale position — and a smooth animation cannot track a moving target: restarting it stutters, fixing
+               it afterwards double-jumps. Hence sample until the position holds still (or the budget runs out), then
+               scroll once. setTimeout gives the fixed sampling interval — and unlike requestAnimationFrame it
+               still fires in a hidden tab. */
             let previous: { top: number; scrollHeight: number } | undefined;
             let quietSamples = 0;
             let remainingChecks = MAX_CHECKS;


### PR DESCRIPTION
## What

Scrolling to the directory targeted by the URL relied on a 700 ms delay before calling `scrollIntoView`, which failed whenever loading and expanding the tree took longer than that. The delay is removed and replaced by a mechanism driven by the actual DOM state.

## How

- New `useScrollIntoViewRef` hook: a callback ref invoked by React exactly when the target `<li>` is attached to the DOM (or immediately when an already-mounted item becomes the target, since the callback identity changes).
- Once attached, the hook samples the item's position relative to the scroll container content every 200 ms and waits for the layout to settle (two consecutive quiet samples — transitions finished, fetched rows inserted), then issues a single smooth `scrollIntoView`. Scrolling only after settling avoids restarting the smooth animation while the layout is still moving, which showed as visible stutter. The wait is bounded (2 s), and the position measure is invariant under scrolling itself, so a manual user scroll does not interfere.
- `TreeViewsContainer` still decides which directory to scroll to (URL fast/slow paths); the scroll itself is delegated to the `CustomTreeItem` owning the directory, which clears the request once done. `CustomTreeItem` no longer needs `forwardRef`.

