### PR TITLE
Add data-testids for end-to-end tests

### DIFF
--- a/src/components/search/search-bar-render-input.tsx
+++ b/src/components/search/search-bar-render-input.tsx
@@ -30,7 +30,7 @@ export function SearchBarRenderInput(props: Readonly<SearchBarRenderInputProps>)
                     ...InputProps,
                     startAdornment: (
                         <>
-                            <Search />
+                            <Search data-testid="SearchIcon" />
                             {InputProps.startAdornment}
                         </>
                     ),


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Add `data-testid` attribute to button components to make them targetable in end-to-end tests:
- `SearchIcon`: search bar in GridExplore

